### PR TITLE
🛡️ Sentinel: Add Nginx security headers and fix config placement

### DIFF
--- a/server-php/Dockerfile
+++ b/server-php/Dockerfile
@@ -120,7 +120,7 @@ WORKDIR /var/www/html
 COPY --chmod=755 --chown=nobody:nobody --from=builder /build /var/www/html
 
 # Copy configuration templates
-COPY --chmod=644 --chown=nobody:nobody config/nginx.conf /etc/nginx/nginx.conf
+COPY --chmod=644 --chown=nobody:nobody config/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --chmod=755 --chown=nobody:nobody config/conf.d /etc/nginx/conf.d/
 COPY --chmod=644 --chown=nobody:nobody config/fpm-pool.conf.template ${PHP_INI_DIR}/php-fpm.d/www.conf.template
 COPY --chmod=644 --chown=nobody:nobody config/php.ini.template ${PHP_INI_DIR}/conf.d/custom.ini.template

--- a/server-php/config/nginx.conf
+++ b/server-php/config/nginx.conf
@@ -16,6 +16,11 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    # Enhanced Security Headers
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:;" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+
     location / {
         try_files $uri $uri/ /index.php?$args;
     }

--- a/server-php/linuxkit.yml
+++ b/server-php/linuxkit.yml
@@ -210,6 +210,11 @@ files:
               add_header X-Content-Type-Options "nosniff" always;
               add_header X-XSS-Protection "1; mode=block" always;
 
+              # Enhanced Security Headers
+              add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:;" always;
+              add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+              add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+
               # Deny hidden files
               location ~ /\. {
                   deny all;


### PR DESCRIPTION
🛡️ Sentinel: [Security Enhancement] Add Nginx security headers and fix Dockerfile config placement

**Enhancement:**
Added defense-in-depth HTTP security headers to the Nginx configuration for the `server-php` image.
- `Content-Security-Policy-Report-Only`: Helps detect XSS and injection attacks without breaking existing functionality.
- `Referrer-Policy: strict-origin-when-cross-origin`: Improves privacy by controlling referrer information.
- `Permissions-Policy`: Disables sensitive features (geolocation, microphone, camera) by default.

**Fix:**
Corrected the `server-php/Dockerfile` to copy the `nginx.conf` (which is a server block fragment) to `/etc/nginx/conf.d/default.conf` instead of overwriting the main `/etc/nginx/nginx.conf`. This ensures the configuration is loaded correctly within the proper Nginx context.

**Verification:**
Verified that `server-php/linuxkit.yml` and `server-php/config/nginx.conf` contain the same headers and that the Dockerfile now places the configuration correctly.

---
*PR created automatically by Jules for task [11174413948926265193](https://jules.google.com/task/11174413948926265193) started by @Snider*