### PR TITLE
🛡️ Sentinel: Enhance Nginx Security Headers & Fix Deployment

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** The `server-php` Dockerfile was overwriting the main `/etc/nginx/nginx.conf` with a server-block fragment, which prevents Nginx from starting correctly (missing events/http context).
 **Learning:** Configurations in `config/` are fragments (server blocks) and must be placed in `conf.d/` while relying on the base image's main configuration.
 **Prevention:** Verify if Nginx configurations contain top-level blocks (`events`, `http`) before replacing the main config. Use `conf.d/default.conf` for site-specific configurations.
+
+## 2026-02-03 - CI Failure: FrankenPHP Asset Naming
+**Vulnerability:** The CI build for `developer` image failed on `linux/arm64` because the `curl` command tried to download `frankenphp-linux-arm64`, but the official asset is named `frankenphp-linux-aarch64`.
+**Learning:** `uname -m` outputs `aarch64` on ARM64 Linux systems. FrankenPHP uses this standard name for its release assets. Remapping it to `arm64` (via `sed`) broke the download.
+**Prevention:** Verify release asset naming conventions before applying architecture remapping. Often `$(uname -m)` matches the asset name directly.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2025-02-18 - Incorrect Nginx Config Deployment
+**Vulnerability:** The `server-php` Dockerfile was overwriting the main `/etc/nginx/nginx.conf` with a server-block fragment, which prevents Nginx from starting correctly (missing events/http context).
+**Learning:** Configurations in `config/` are fragments (server blocks) and must be placed in `conf.d/` while relying on the base image's main configuration.
+**Prevention:** Verify if Nginx configurations contain top-level blocks (`events`, `http`) before replacing the main config. Use `conf.d/default.conf` for site-specific configurations.

--- a/developer/Dockerfile
+++ b/developer/Dockerfile
@@ -106,7 +106,7 @@ RUN composer global config allow-plugins.pestphp/pest-plugin true && \
     laravel/pint:^1.0
 
 # FrankenPHP (static binary)
-RUN curl -fsSL "https://github.com/dunglas/frankenphp/releases/latest/download/frankenphp-linux-$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/x86_64/')" -o /usr/local/bin/frankenphp && \
+RUN curl -fsSL "https://github.com/dunglas/frankenphp/releases/latest/download/frankenphp-linux-$(uname -m)" -o /usr/local/bin/frankenphp && \
     chmod +x /usr/local/bin/frankenphp
 
 # ============================================================

--- a/server-php/Dockerfile
+++ b/server-php/Dockerfile
@@ -120,7 +120,7 @@ WORKDIR /var/www/html
 COPY --chmod=755 --chown=nobody:nobody --from=builder /build /var/www/html
 
 # Copy configuration templates
-COPY --chmod=644 --chown=nobody:nobody config/nginx.conf /etc/nginx/nginx.conf
+COPY --chmod=644 --chown=nobody:nobody config/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --chmod=755 --chown=nobody:nobody config/conf.d /etc/nginx/conf.d/
 COPY --chmod=644 --chown=nobody:nobody config/fpm-pool.conf.template ${PHP_INI_DIR}/php-fpm.d/www.conf.template
 COPY --chmod=644 --chown=nobody:nobody config/php.ini.template ${PHP_INI_DIR}/conf.d/custom.ini.template

--- a/server-php/config/nginx.conf
+++ b/server-php/config/nginx.conf
@@ -15,6 +15,9 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+    add_header Permissions-Policy "geolocation=(), midi=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), fullscreen=(self), payment=()" always;
 
     location / {
         try_files $uri $uri/ /index.php?$args;

--- a/server-php/linuxkit.yml
+++ b/server-php/linuxkit.yml
@@ -209,6 +209,9 @@ files:
               add_header X-Frame-Options "SAMEORIGIN" always;
               add_header X-Content-Type-Options "nosniff" always;
               add_header X-XSS-Protection "1; mode=block" always;
+              add_header Referrer-Policy "no-referrer-when-downgrade" always;
+              add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+              add_header Permissions-Policy "geolocation=(), midi=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), fullscreen=(self), payment=()" always;
 
               # Deny hidden files
               location ~ /\. {


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

💡 Vulnerability:
1. Missing standard security headers (CSP, Referrer-Policy, Permissions-Policy) in Nginx configuration.
2. `server-php` Dockerfile incorrectly overwrote the main `/etc/nginx/nginx.conf` with a server block fragment, which would cause Nginx to fail to start or misbehave.

🔧 Fix:
1. Added `Referrer-Policy`, `Content-Security-Policy`, and `Permissions-Policy` to `server-php/config/nginx.conf`.
2. Updated `server-php/Dockerfile` to copy `nginx.conf` to `/etc/nginx/conf.d/default.conf`.
3. Synchronized `server-php/linuxkit.yml` embedded config with the new headers.

✅ Verification:
- Verified Nginx configuration syntax (manually, as local build environment is limited).
- Verified Dockerfile COPY instruction change.

---
*PR created automatically by Jules for task [16074583272332722603](https://jules.google.com/task/16074583272332722603) started by @Snider*