### PR TITLE
🛡️ Sentinel: Enhance server-php Nginx security headers

### DIFF
--- a/server-php/config/nginx.conf
+++ b/server-php/config/nginx.conf
@@ -10,9 +10,12 @@ server {
     index index.php;
 
     client_max_body_size 64M;
+    server_tokens off;
 
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "geolocation=(), midi=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), fullscreen=(self), payment=()" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
 

--- a/server-php/linuxkit.yml
+++ b/server-php/linuxkit.yml
@@ -170,6 +170,7 @@ files:
           tcp_nodelay on;
           keepalive_timeout 65;
           types_hash_max_size 2048;
+          server_tokens off;
 
           # Gzip compression
           gzip on;
@@ -209,6 +210,8 @@ files:
               add_header X-Frame-Options "SAMEORIGIN" always;
               add_header X-Content-Type-Options "nosniff" always;
               add_header X-XSS-Protection "1; mode=block" always;
+              add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+              add_header Permissions-Policy "geolocation=(), midi=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), fullscreen=(self), payment=()" always;
 
               # Deny hidden files
               location ~ /\. {


### PR DESCRIPTION
Sentinel 🛡️ Security Enhancement

**Vulnerability:** Missing `Referrer-Policy` and `Permissions-Policy` headers, and Nginx version exposure.
**Impact:** Information leakage (referrer data, server version) and potential abuse of browser features.
**Fix:** Added security headers and disabled server tokens in both Docker and LinuxKit configurations.
**Verification:** Verified by code inspection of Nginx configuration files.

---
*PR created automatically by Jules for task [7510476890067934715](https://jules.google.com/task/7510476890067934715) started by @Snider*