### PR TITLE
🛡️ Sentinel: Fix server-php nginx config & add security headers

### DIFF
--- a/server-php/config/nginx.conf
+++ b/server-php/config/nginx.conf
@@ -1,63 +1,106 @@
-upstream php-fpm {
-    server host-uk-dev-wordpress:9000;
+worker_processes auto;
+error_log /dev/stderr warn;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 1024;
+    multi_accept on;
+    use epoll;
 }
 
-server {
-    listen 80;
-    server_name _;
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
 
-    root /var/www/html;
-    index index.php;
+    # Basic Settings
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    server_tokens off;
 
-    client_max_body_size 64M;
+    # Logging
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /dev/stdout main;
 
-    # Security headers
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-XSS-Protection "1; mode=block" always;
+    # Gzip
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
 
-    location / {
-        try_files $uri $uri/ /index.php?$args;
+    # Upstream to PHP-FPM
+    upstream php-fpm {
+        server unix:/run/php-fpm.sock;
     }
 
-    location ~ \.php$ {
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass php-fpm;
-        fastcgi_index index.php;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_param PATH_INFO $fastcgi_path_info;
-        fastcgi_param HTTP_X_FORWARDED_PROTO $http_x_forwarded_proto;
-        fastcgi_buffering off;
-        fastcgi_read_timeout 300;
-    }
+    server {
+        listen 80;
+        server_name _;
 
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-        expires max;
-        log_not_found off;
-        access_log off;
-    }
+        root /var/www/html;
+        index index.php;
 
-    location = /favicon.ico {
-        log_not_found off;
-        access_log off;
-    }
+        client_max_body_size 64M;
 
-    location = /robots.txt {
-        allow all;
-        log_not_found off;
-        access_log off;
-    }
+        # Security headers
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
 
-    location ~ /\. {
-        deny all;
-        access_log off;
-        log_not_found off;
-    }
+        location / {
+            try_files $uri $uri/ /index.php?$args;
+        }
 
-    location ~ ~$ {
-        access_log off;
-        log_not_found off;
-        deny all;
+        location ~ \.php$ {
+            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            fastcgi_pass php-fpm;
+            fastcgi_index index.php;
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_param PATH_INFO $fastcgi_path_info;
+            fastcgi_param HTTP_X_FORWARDED_PROTO $http_x_forwarded_proto;
+            fastcgi_buffering off;
+            fastcgi_read_timeout 300;
+            fastcgi_hide_header X-Powered-By;
+        }
+
+        # Static assets
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            expires max;
+            log_not_found off;
+            access_log off;
+        }
+
+        location = /favicon.ico {
+            log_not_found off;
+            access_log off;
+        }
+
+        location = /robots.txt {
+            allow all;
+            log_not_found off;
+            access_log off;
+        }
+
+        # Block hidden files
+        location ~ /\. {
+            deny all;
+            access_log off;
+            log_not_found off;
+        }
+
+        # Block backup files
+        location ~ ~$ {
+            access_log off;
+            log_not_found off;
+            deny all;
+        }
     }
 }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix broken Nginx configuration and add security headers

🚨 Severity: HIGH (due to broken base image configuration) / MEDIUM (security enhancements)
💡 Vulnerability:
1.  **Availability/Configuration:** The `server-php/config/nginx.conf` file was a partial configuration lacking `events` and `http` blocks, which overwrites `/etc/nginx/nginx.conf` in the Docker image, preventing Nginx from starting.
2.  **Connectivity/SSRF Risk:** The upstream `php-fpm` was pointing to `host-uk-dev-wordpress:9000` (an external/undefined host) instead of the local unix socket `/run/php-fpm.sock` where PHP-FPM is listening.
3.  **Security Headers:** Missing `Referrer-Policy`, `Permissions-Policy`, and `server_tokens` leakage.

🎯 Impact:
- The `server-php` Docker image was unusable out of the box (would fail to start or connect to PHP-FPM).
- Potential for traffic misdirection or SSRF if `host-uk-dev-wordpress` resolved to a malicious host.
- Missing headers reduced defense-in-depth posture.

🔧 Fix:
- Rewrote `server-php/config/nginx.conf` to be a complete, valid Nginx configuration matching the structure of the working `server-php/linuxkit.yml`.
- Corrected the `upstream php-fpm` to use the local unix socket.
- Added strict security headers and disabled server tokens.

✅ Verification:
- Manually verified the configuration against `server-php/linuxkit.yml` (known good config).
- Verified `server-php/config/fpm-pool.conf.template` uses the same unix socket path.
- Verified `server-php/config/supervisord.conf` runs both services in the same container.
- Note: `docker build` verification was attempted but failed due to Docker Hub rate limits in the CI environment; however, static analysis confirms the fix addresses the fundamental configuration errors.

---
*PR created automatically by Jules for task [17834381188405714887](https://jules.google.com/task/17834381188405714887) started by @Snider*