### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC token

### DIFF
--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -45,6 +45,8 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
 
     # WordPress multisite rewrite rules
     location / {
@@ -105,17 +107,12 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC by default
+    # To enable, set $xmlrpc_allowed to 1 based on a valid token or IP whitelist
     location = /xmlrpc.php {
         set $xmlrpc_allowed 0;
 
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
+        # Block if not allowed
         if ($xmlrpc_allowed = 0) {
             return 403;
         }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token ("xrpc-9f8e7d6c5b4a") was found in `server-php/config/conf.d/wordpress.conf` which allowed bypassing the XML-RPC block.
🎯 Impact: Attackers could bypass XML-RPC protections and potentially brute-force passwords or exploit XML-RPC vulnerabilities if they knew or guessed this token.
🔧 Fix: Removed the hardcoded token check. XML-RPC is now blocked by default unless explicitly re-enabled via configuration changes. Added missing security headers (Referrer-Policy, Permissions-Policy) as a defense-in-depth enhancement.
✅ Verification: Verified the configuration file no longer contains the token and includes the new headers.

---
*PR created automatically by Jules for task [9955783795391402977](https://jules.google.com/task/9955783795391402977) started by @Snider*