### PR TITLE
🛡️ Sentinel: Add Referrer-Policy and Permissions-Policy security headers

### DIFF
--- a/server-php/config/nginx.conf
+++ b/server-php/config/nginx.conf
@@ -15,6 +15,8 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=(), vr=()" always;
 
     location / {
         try_files $uri $uri/ /index.php?$args;

--- a/server-php/linuxkit.yml
+++ b/server-php/linuxkit.yml
@@ -209,6 +209,8 @@ files:
               add_header X-Frame-Options "SAMEORIGIN" always;
               add_header X-Content-Type-Options "nosniff" always;
               add_header X-XSS-Protection "1; mode=block" always;
+              add_header Referrer-Policy "no-referrer-when-downgrade" always;
+              add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=(), vr=()" always;
 
               # Deny hidden files
               location ~ /\. {


### PR DESCRIPTION
Added `Referrer-Policy` and `Permissions-Policy` security headers to `server-php` Nginx configuration.

- `Referrer-Policy: no-referrer-when-downgrade`: Prevents sending the referrer header when navigating from HTTPS to HTTP.
- `Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), vr=()`: Disables access to sensitive browser features by default.

These headers are added to both `server-php/config/nginx.conf` (for Docker image) and `server-php/linuxkit.yml` (for LinuxKit image) to ensure consistency.

---
*PR created automatically by Jules for task [2142529677427001100](https://jules.google.com/task/2142529677427001100) started by @Snider*