### PR TITLE
🛡️ Sentinel: [CRITICAL] Remove hardcoded XML-RPC token

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - Hardcoded Secret in Nginx Config
+**Vulnerability:** Found a hardcoded token 'xrpc-9f8e7d6c5b4a' in 'server-php/config/conf.d/wordpress.conf' used to bypass XML-RPC blocking.
+**Learning:** Hardcoding secrets in config files for 'convenience' is a common pattern that gets committed to version control. Nginx configs often lack environment variable support, leading to this anti-pattern.
+**Prevention:** Use environment variables and envsubst at runtime to inject secrets, or use a proper secret management system. Never commit secrets to the repo.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,12 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC by default (security hardening)
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
+        return 403;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
Removed a hardcoded secret token from `server-php/config/conf.d/wordpress.conf`. This token was used to bypass the XML-RPC block, but being committed to the repository made it public knowledge, defeating its purpose and exposing the installation to attacks. The configuration now denies all access to `/xmlrpc.php` by default.

---
*PR created automatically by Jules for task [5775224859846163084](https://jules.google.com/task/5775224859846163084) started by @Snider*