### PR TITLE
🛡️ Sentinel: Add Referrer-Policy and Permissions-Policy headers

### DIFF
--- a/server-php/config/nginx.conf
+++ b/server-php/config/nginx.conf
@@ -10,11 +10,14 @@ server {
     index index.php;
 
     client_max_body_size 64M;
+    server_tokens off;
 
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Permissions-Policy "interest-cohort=()" always;
 
     location / {
         try_files $uri $uri/ /index.php?$args;

--- a/server-php/linuxkit.yml
+++ b/server-php/linuxkit.yml
@@ -170,6 +170,7 @@ files:
           tcp_nodelay on;
           keepalive_timeout 65;
           types_hash_max_size 2048;
+          server_tokens off;
 
           # Gzip compression
           gzip on;
@@ -209,6 +210,8 @@ files:
               add_header X-Frame-Options "SAMEORIGIN" always;
               add_header X-Content-Type-Options "nosniff" always;
               add_header X-XSS-Protection "1; mode=block" always;
+              add_header Referrer-Policy "no-referrer-when-downgrade" always;
+              add_header Permissions-Policy "interest-cohort=()" always;
 
               # Deny hidden files
               location ~ /\. {


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

💡 Vulnerability: Missing HTTP security headers allow potential privacy leaks (Referrer-Policy) and unwanted tracking (Permissions-Policy).
🎯 Impact: Improved privacy and security posture by restricting referrer information and blocking FLoC.
🔧 Fix: Added `Referrer-Policy: no-referrer-when-downgrade` and `Permissions-Policy: interest-cohort=()` to both Docker and LinuxKit Nginx configurations. Also disabled `server_tokens` to hide Nginx version.
✅ Verification: Verified file content includes the new headers.

---
*PR created automatically by Jules for task [2798856542500201217](https://jules.google.com/task/2798856542500201217) started by @Snider*