### PR TITLE
🛡️ Sentinel: [CRITICAL] Remove hardcoded XML-RPC secret and harden Nginx

### DIFF
--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,10 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC for security
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        return 403;
+        access_log off;
     }
 
     # Deny access to hidden files

--- a/server-php/config/nginx.conf
+++ b/server-php/config/nginx.conf
@@ -5,6 +5,7 @@ upstream php-fpm {
 server {
     listen 80;
     server_name _;
+    server_tokens off;
 
     root /var/www/html;
     index index.php;
@@ -15,6 +16,8 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Permissions-Policy "interest-cohort=()" always;
 
     location / {
         try_files $uri $uri/ /index.php?$args;

--- a/server-php/linuxkit.yml
+++ b/server-php/linuxkit.yml
@@ -183,6 +183,7 @@ files:
               listen 80;
               listen [::]:80;
               server_name _;
+              server_tokens off;
 
               root /var/www/html/public;
               index index.php index.html;
@@ -209,6 +210,8 @@ files:
               add_header X-Frame-Options "SAMEORIGIN" always;
               add_header X-Content-Type-Options "nosniff" always;
               add_header X-XSS-Protection "1; mode=block" always;
+              add_header Referrer-Policy "no-referrer-when-downgrade" always;
+              add_header Permissions-Policy "interest-cohort=()" always;
 
               # Deny hidden files
               location ~ /\. {


### PR DESCRIPTION
This PR addresses a critical security vulnerability and adds security enhancements:

1.  **Critical Fix**: Removed a hardcoded secret token (`xrpc-9f8e7d6c5b4a`) that was used to bypass XML-RPC blocking in `server-php/config/conf.d/wordpress.conf`. The endpoint is now unconditionally blocked with a 403 Forbidden response.
2.  **Security Hardening**:
    *   Added `server_tokens off;` to hide Nginx version information.
    *   Added `Referrer-Policy: no-referrer-when-downgrade` header.
    *   Added `Permissions-Policy: interest-cohort=()` header.
    *   Applied these changes to both the Docker configuration (`server-php/config/nginx.conf`) and the LinuxKit embedded configuration (`server-php/linuxkit.yml`).

These changes improve the security posture by removing a potential backdoor and adding defense-in-depth headers.

---
*PR created automatically by Jules for task [2697934226313323984](https://jules.google.com/task/2697934226313323984) started by @Snider*