### PR TITLE
🛡️ Sentinel: Fix critical hardcoded XML-RPC secret token

### DIFF
--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,12 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC to prevent brute force attacks and DDoS
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
+        return 403;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret token

🚨 Severity: CRITICAL
💡 Vulnerability: Hardcoded secret token `xrpc-9f8e7d6c5b4a` in `server-php/config/conf.d/wordpress.conf` allowed bypassing XML-RPC restrictions.
🎯 Impact: Attackers could use the exposed token to access `/xmlrpc.php` for brute force attacks or DDoS amplification.
🔧 Fix: Removed the token check and unconditionally blocked access to `/xmlrpc.php` (returns 403 Forbidden).
✅ Verification: Verified by inspecting the configuration file and confirming the secret is removed and the block is in place.


---
*PR created automatically by Jules for task [13522588183993412142](https://jules.google.com/task/13522588183993412142) started by @Snider*