### PR TITLE
🛡️ Sentinel: [CRITICAL] Remove hardcoded XML-RPC token

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-27 - Hardcoded XML-RPC Token
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was found in `server-php/config/conf.d/wordpress.conf` used to gate access to `xmlrpc.php`.
+**Learning:** Developers likely intended this as a placeholder or a quick way to secure XML-RPC without fully disabling it, but committed the secret to the repository.
+**Prevention:** Use environment variables for secrets, or disable risky features like XML-RPC by default if they are not needed. Never commit secrets to version control.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,12 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC access
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
+        return 403;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Hardcoded secret token found in `server-php/config/conf.d/wordpress.conf` used to gate XML-RPC access.
🎯 Impact: Attackers could potentially bypass security controls or use the token to launch attacks against the WordPress instance via XML-RPC (e.g. brute force, DDoS amplification).
🔧 Fix: Removed the hardcoded token check and unconditionally blocked access to `/xmlrpc.php` with a 403 Forbidden response.
✅ Verification: Verified manually that the token is removed and the configuration syntax is correct.

---
*PR created automatically by Jules for task [11501997558747442571](https://jules.google.com/task/11501997558747442571) started by @Snider*