### PR TITLE
🛡️ Sentinel: [CRITICAL] Remove hardcoded XML-RPC token from server-php

### DIFF
--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,9 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC by default for security
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        return 403;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was found in `server-php/config/conf.d/wordpress.conf` allowing XML-RPC access.
🎯 **Impact:** If exploited, attackers could use XML-RPC for brute force attacks or DDoS amplification. The hardcoded token essentially acted as a backdoor.
🔧 **Fix:** Removed the hardcoded token and the logic that allowed access. Replaced with an unconditional `return 403;` to block all XML-RPC requests.
✅ **Verification:** Verified by code inspection. Docker build was attempted but failed due to environment constraints, but the Nginx configuration syntax is standard and correct.

---
*PR created automatically by Jules for task [14213758314948055720](https://jules.google.com/task/14213758314948055720) started by @Snider*