### PR TITLE
🛡️ Sentinel: [CRITICAL] Remove hardcoded XML-RPC secret

### DIFF
--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,13 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC completely
+    # Prevents brute force attacks and DDoS amplification
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
+        return 403;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
Removed a hardcoded secret token used to bypass XML-RPC restrictions in the Nginx configuration. This endpoint is now unconditionally blocked to improve security posture and prevent abuse.

---
*PR created automatically by Jules for task [14427647706516349582](https://jules.google.com/task/14427647706516349582) started by @Snider*