### PR TITLE
🛡️ Sentinel: Fix critical hardcoded secret in Nginx config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Hardcoded Secret in Nginx Config
+**Vulnerability:** Found a hardcoded secret token (`xrpc-9f8e7d6c5b4a`) in `server-php/config/conf.d/wordpress.conf` used to bypass XML-RPC block.
+**Learning:** Hardcoded secrets in configuration files are critical vulnerabilities. Nginx configs are often overlooked for secrets.
+**Prevention:** Use environment variables for secrets, or better yet, avoid bypass mechanisms based on static tokens. Always block XML-RPC unless strictly necessary.

--- a/server-php/config/conf.d/unified.conf
+++ b/server-php/config/conf.d/unified.conf
@@ -29,6 +29,9 @@ server {
 
     client_max_body_size 64M;
 
+    # Hide Nginx version
+    server_tokens off;
+
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
@@ -116,6 +119,9 @@ server {
     index index.php;
 
     client_max_body_size 64M;
+
+    # Hide Nginx version
+    server_tokens off;
 
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -41,6 +41,9 @@ server {
 
     client_max_body_size 64M;
 
+    # Hide Nginx version
+    server_tokens off;
+
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
@@ -105,28 +108,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC by default to prevent brute force attacks
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🛡️ Sentinel Security Patch

**Vulnerability:**
Found a hardcoded secret token (`xrpc-9f8e7d6c5b4a`) in `server-php/config/conf.d/wordpress.conf` that allowed bypassing the XML-RPC block. This is a critical security risk as it exposes the XML-RPC interface to brute force attacks if the token is leaked or guessed.

**Fix:**
- Removed the hardcoded secret check.
- Replaced the logic with an unconditional `deny all;` for `/xmlrpc.php`.
- Added `server_tokens off;` to Nginx configurations to prevent version disclosure.

**Verification:**
- Manually verified the configuration files to ensure the secret is removed and the block is correct.
- Confirmed that `server_tokens off;` is present in both `unified.conf` and `wordpress.conf`.

**Impact:**
- Prevents potential unauthorized access via XML-RPC.
- Improves security posture by hiding server version information.


---
*PR created automatically by Jules for task [17981241887021882589](https://jules.google.com/task/17981241887021882589) started by @Snider*