### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret and hide server tokens

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-17 - Hardcoded Secrets in Nginx Config
+**Vulnerability:** Found a hardcoded secret token (`xrpc-9f8e7d6c5b4a`) embedded directly in an Nginx configuration file (`wordpress.conf`) to bypass an XML-RPC block.
+**Learning:** Secrets can hide in infrastructure configuration files (Nginx, HAProxy, etc.) as logic checks (e.g., `if ($arg_token = "...")`), not just in application code or `.env` files.
+**Prevention:** Never hardcode secrets in Nginx logic. Use `deny all` by default for sensitive endpoints like `xmlrpc.php`. If access is needed, use upstream authentication or at least environment variables (though Nginx makes env vars hard without Lua/envsubst).

--- a/server-php/config/conf.d/unified.conf
+++ b/server-php/config/conf.d/unified.conf
@@ -29,6 +29,9 @@ server {
 
     client_max_body_size 64M;
 
+    # Hide Nginx version
+    server_tokens off;
+
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
@@ -116,6 +119,9 @@ server {
     index index.php;
 
     client_max_body_size 64M;
+
+    # Hide Nginx version
+    server_tokens off;
 
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -41,6 +41,9 @@ server {
 
     client_max_body_size 64M;
 
+    # Hide Nginx version
+    server_tokens off;
+
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
@@ -105,28 +108,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC by default to prevent brute force attacks
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
This PR addresses a critical security vulnerability where a hardcoded secret was used to bypass XML-RPC blocking in the Nginx configuration. It also enhances security by hiding the Nginx version information.

**Changes:**
- Removed `location = /xmlrpc.php { ... }` block with hardcoded secret check in `server-php/config/conf.d/wordpress.conf`.
- Added `deny all;` block for `/xmlrpc.php` in `server-php/config/conf.d/wordpress.conf`.
- Added `server_tokens off;` to `server-php/config/conf.d/wordpress.conf` and `server-php/config/conf.d/unified.conf`.

**Verification:**
- Manually verified the configuration files to ensure the secret is removed and directives are correct.
- Added entry to `.jules/sentinel.md` documenting the finding.


---
*PR created automatically by Jules for task [14163410803209890320](https://jules.google.com/task/14163410803209890320) started by @Snider*