### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret in WordPress config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-23 - Hardcoded XML-RPC Secret
+**Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in `server-php/config/conf.d/wordpress.conf` allowing bypass of the XML-RPC block.
+**Learning:** Hardcoding secrets in configuration files, even for "internal" bypasses, is a critical security risk as the code is visible to anyone with repository access.
+**Prevention:** Use environment variables for secrets, or better yet, disable insecure features like XML-RPC entirely if they are not needed. If access is required, use proper authentication mechanisms.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,12 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC access
+    # This feature is disabled for security reasons (brute-force attacks)
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
This PR addresses a critical security vulnerability where a hardcoded secret token was used to bypass XML-RPC restrictions in the Nginx configuration.

Changes:
- Modified `server-php/config/conf.d/wordpress.conf` to remove the secret and unconditionally deny access to `/xmlrpc.php`.
- Created `.jules/sentinel.md` to document this critical finding and learning, as per Sentinel protocol.

This change follows the "Fail Secure" principle by disabling the insecure feature entirely rather than relying on a weak secret.

---
*PR created automatically by Jules for task [183861082289104561](https://jules.google.com/task/183861082289104561) started by @Snider*