### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret in Nginx config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Hardcoded Secret in Nginx Config
+**Vulnerability:** Found a hardcoded secret token `xrpc-9f8e7d6c5b4a` in `server-php/config/conf.d/wordpress.conf` used to bypass XML-RPC blocking.
+**Learning:** Configuration files, especially for web servers like Nginx, can be overlooked sources of hardcoded secrets. Developers might add "backdoors" for convenience that become security risks.
+**Prevention:** Always scan configuration files for secrets. Use environment variables or separate secret files for sensitive tokens, never commit them to the repo. If an endpoint is meant to be blocked, block it unconditionally unless there is a strong, secure requirement to allow it.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC access
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret in Nginx config

🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in `server-php/config/conf.d/wordpress.conf`. This token allowed bypassing the block on `/xmlrpc.php`.
🎯 Impact: Attackers who discovered this token could access the XML-RPC endpoint, potentially enabling brute-force attacks or DDoS amplification.
🔧 Fix: Removed the token check logic and replaced it with `deny all;` for `/xmlrpc.php`.
✅ Verification: Verified by reading the configuration file to ensure the secret is removed and the syntax is correct. Checked that the location block now unconditionally denies access.

---
*PR created automatically by Jules for task [7280852009733243451](https://jules.google.com/task/7280852009733243451) started by @Snider*