### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - [Hardcoded Secrets in Nginx Config]
+**Vulnerability:** A hardcoded XML-RPC bypass token (`xrpc-9f8e7d6c5b4a`) was found directly in `server-php/config/conf.d/wordpress.conf`.
+**Learning:** Developers sometimes use hardcoded query parameters in Nginx `if` blocks to create "hidden" backdoors for maintenance or legacy API access, bypassing standard authentication. This is dangerous because Nginx configs are often checked into version control.
+**Prevention:** Never hardcode secrets in Nginx configurations. If an endpoint needs protection, use proper upstream authentication, IP allowlisting, or environment variables (if supported by the startup script, e.g., via `envsubst`). For XML-RPC, it's safer to block it entirely if not strictly needed.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC to prevent brute force attacks
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in `server-php/config/conf.d/wordpress.conf` which allowed bypassing the XML-RPC block.
🎯 Impact: Attackers knowing this token could access the XML-RPC endpoint, enabling brute force attacks or other exploits.
🔧 Fix: Removed the hardcoded secret check and replaced the block with an unconditional `deny all;` for `/xmlrpc.php`.
✅ Verification: Verified using `verify_fix.py` script which confirmed the secret is gone and the deny rule is present.

---
*PR created automatically by Jules for task [4397270396786907344](https://jules.google.com/task/4397270396786907344) started by @Snider*