### PR TITLE
🛡️ Sentinel: [MEDIUM] Hide Nginx server version info

### DIFF
--- a/server-php/config/nginx.conf
+++ b/server-php/config/nginx.conf
@@ -10,6 +10,7 @@ server {
     index index.php;
 
     client_max_body_size 64M;
+    server_tokens off;
 
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;

--- a/server-php/linuxkit.yml
+++ b/server-php/linuxkit.yml
@@ -165,6 +165,8 @@ files:
 
           access_log /dev/stdout main;
 
+          server_tokens off;
+
           sendfile on;
           tcp_nopush on;
           tcp_nodelay on;


### PR DESCRIPTION
🛡️ Sentinel: Hide Nginx server version info

🚨 Severity: MEDIUM
💡 Vulnerability: Nginx exposes its exact version number in the `Server` HTTP response header and on default error pages. This information disclosure can be used by attackers to target version-specific vulnerabilities.
🎯 Impact: Attackers could easily identify the Nginx version and look up associated CVEs, potentially exploiting known vulnerabilities.
🔧 Fix: Added `server_tokens off;` to `server-php/config/nginx.conf` and `server-php/linuxkit.yml` to prevent exposing Nginx version information.
✅ Verification: Verified that the `server_tokens off;` directive is correctly placed in the `http` or `server` blocks of both configuration files.

---
*PR created automatically by Jules for task [5160776804003686959](https://jules.google.com/task/5160776804003686959) started by @Snider*