### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded token bypass for XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Hardcoded Token in Nginx Config]
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was used in an Nginx configuration (`wordpress.conf`) to bypass the block on `/xmlrpc.php` via query parameter (`$arg_token`).
+**Learning:** Nginx configurations are often treated as infrastructure code and not properly scanned for secrets. Using Nginx `if` statements with query parameters for authentication is insecure because the secret is hardcoded, cannot be rotated dynamically, and can be exposed in version control or access logs.
+**Prevention:** Never use hardcoded secrets for access control in Nginx configurations. Rely on proper upstream authentication mechanisms, environment variables (if supported by the proxy), or unconditional blocks for legacy endpoints like `xmlrpc.php`.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC completely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` which allowed bypassing the Nginx block on `/xmlrpc.php`. Hardcoded secrets are a critical security vulnerability, as they cannot be securely rotated and are exposed in version control.
🎯 **Impact:** If exploited or leaked, this would allow an attacker to make XML-RPC requests against the WordPress instances, potentially leading to brute force attacks, DDoS amplification, or exploitation of XML-RPC specific vulnerabilities.
🔧 **Fix:** Replaced the token-based bypass with an unconditional `deny all;` block for `/xmlrpc.php`, preventing any access and removing the hardcoded secret from the configuration entirely.
✅ **Verification:** Verified that the hardcoded string `xrpc-9f8e7d6c5b4a` is completely removed from the Nginx configuration via `grep`. Also created a `.jules/sentinel.md` journal entry with critical learnings.

---
*PR created automatically by Jules for task [17025297211965933602](https://jules.google.com/task/17025297211965933602) started by @Snider*