### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded token bypass in Nginx config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [CRITICAL] Hardcoded Token Bypass in Nginx Configuration
+**Vulnerability:** A hardcoded token (`$arg_token = "xrpc-9f8e7d6c5b4a"`) was found in the Nginx configuration `server-php/config/conf.d/wordpress.conf`. It was intended to block `/xmlrpc.php` but acted as a backdoor, allowing anyone with the token to bypass the block.
+**Learning:** Hardcoding secrets or bypass mechanisms inside web server configuration files (like Nginx `conf.d` files) can create critical hidden entry points or backdoors. These bypasses defeat the purpose of protective measures.
+**Prevention:** Avoid putting hardcoded secrets or bypass tokens in configuration files. If an exception is absolutely necessary, use robust authentication mechanisms or IP whitelisting rather than static secret tokens.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally to prevent abuse
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was found in the Nginx configuration `server-php/config/conf.d/wordpress.conf`. It was intended to block `/xmlrpc.php` but acted as a backdoor, allowing anyone with the token to bypass the block.
🎯 **Impact:** If exploited, attackers could bypass the intended block on XML-RPC and launch brute force or DoS attacks against the WordPress application.
🔧 **Fix:** Replaced the conditional block and token logic with an unconditional `deny all;` directive for `location = /xmlrpc.php`.
✅ **Verification:** Verified that the Nginx configuration syntax is intact and the journal entry has been properly created and formatted.

---
*PR created automatically by Jules for task [8933830452377667687](https://jules.google.com/task/8933830452377667687) started by @Snider*