### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded token bypass for XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-19 - [Hardcoded Secret Token Bypass in Nginx]
+**Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was used in Nginx configuration (`wordpress.conf`) to conditionally bypass blocks on `/xmlrpc.php` via `$arg_token`.
+**Learning:** Checking query parameters like `$arg_token` against hardcoded string values in configuration files introduces a severe security risk. This bypass mechanism is trivially exploitable if the static configuration is ever exposed or leaked.
+**Prevention:** Avoid hardcoded secrets in configuration files. If an exception is strictly required, rely on standard upstream authentication mechanisms or unconditional blocks (`deny all;`) for dangerous endpoints.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was used in the Nginx configuration (`wordpress.conf`) to conditionally bypass access restrictions on `/xmlrpc.php` by checking `$arg_token`.
🎯 **Impact:** If the static Nginx configuration was exposed or leaked, an attacker could trivially bypass security restrictions and access the WordPress XML-RPC endpoint, opening up vectors for brute-force attacks and DDoS amplification.
🔧 **Fix:** Removed the hardcoded token bypass logic and replaced it with a standard, unconditional `deny all;` block for the `/xmlrpc.php` location.
✅ **Verification:** Verified Nginx syntax locally using `awk` to check block balances. A Docker build was attempted but hit rate limits. The configuration now unambiguously blocks all traffic to `/xmlrpc.php`.

Additionally, documented this vulnerability pattern in the Sentinel Journal (`.jules/sentinel.md`).

---
*PR created automatically by Jules for task [2086783263184636419](https://jules.google.com/task/2086783263184636419) started by @Snider*