### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass for XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-30 - Fix hardcoded secret bypass for XML-RPC
+**Vulnerability:** A hardcoded secret (`xrpc-9f8e7d6c5b4a`) was used in `server-php/config/conf.d/wordpress.conf` to bypass the XML-RPC block. This allowed anyone with the token to access `/xmlrpc.php`, which is a known vector for brute-force attacks and DDoS.
+**Learning:** Nginx configurations should never use hardcoded `$arg_` tokens for authentication or bypass mechanisms, as these secrets can be leaked or easily guessed. Nginx configs are often stored in plain text and are not designed for secure secret management.
+**Prevention:** Remove the conditional bypass entirely and implement an unconditional `deny all;` for `/xmlrpc.php`. If XML-RPC is absolutely required, use standard authentication mechanisms (e.g., HTTP Basic Auth) or secure upstream proxies, rather than hardcoded query parameter tokens.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC completely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded secret (`xrpc-9f8e7d6c5b4a`) was used in `server-php/config/conf.d/wordpress.conf` to bypass the XML-RPC block, which could lead to unauthorized access if the token leaked.
🎯 **Impact:** Exposes `/xmlrpc.php`, which is a well-known vector for brute-force and DDoS amplification attacks against WordPress.
🔧 **Fix:** Replaced the conditional bypass completely with an unconditional `deny all;` directive.
✅ **Verification:** Changes manually verified in `server-php/config/conf.d/wordpress.conf`. Added entry to Sentinel journal as instructed.

---
*PR created automatically by Jules for task [14076394384706801692](https://jules.google.com/task/14076394384706801692) started by @Snider*