### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret and authentication bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Hardcoded secret in Nginx config
+**Vulnerability:** Found a hardcoded secret token (`xrpc-9f8e7d6c5b4a`) used to bypass the block on `/xmlrpc.php` in `server-php/config/conf.d/wordpress.conf`.
+**Learning:** Hardcoded secrets in configuration files are easily exposed and cannot be rotated securely without a deployment. They provide a false sense of security and a persistent backdoor if leaked.
+**Prevention:** Never use hardcoded secrets for authentication in server configurations. Instead, disable unnecessary endpoints completely (like `xmlrpc.php`), or implement proper authentication mechanisms (e.g., standard HTTP basic auth, API gateways, or upstream authentication).

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Found a hardcoded secret token (`xrpc-9f8e7d6c5b4a`) used to bypass the block on `/xmlrpc.php` in `server-php/config/conf.d/wordpress.conf`.
🎯 **Impact:** If the token is leaked or discovered, attackers can bypass the intended block on XML-RPC. Hardcoded secrets cannot be easily rotated without a redeploy. This exposes the site to common brute force and DDoS attacks via XML-RPC.
🔧 **Fix:** Replaced the conditional access logic with an unconditional `deny all;` block, and turned off logging for the endpoint to reduce log pollution.
✅ **Verification:** Changes to `wordpress.conf` can be reviewed in the diff. Additionally, a new entry was created in `.jules/sentinel.md` documenting the vulnerability and prevention strategies.

---
*PR created automatically by Jules for task [2387402148735089136](https://jules.google.com/task/2387402148735089136) started by @Snider*