### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded token in Nginx xmlrpc config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+# Sentinel Journal
+## 2024-05-24 - [CRITICAL] Hardcoded Token in Nginx Configuration
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was found in `server-php/config/conf.d/wordpress.conf` allowing access to `/xmlrpc.php`.
+**Learning:** Nginx configuration files were being used directly without environment variable substitution, leading to the hardcoding of secrets.
+**Prevention:** Remove the hardcoded secret check and replace it with an unconditional `deny all;` block for `/xmlrpc.php`.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,9 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally to prevent access with hardcoded tokens
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was found in the `location = /xmlrpc.php` block of the `server-php/config/conf.d/wordpress.conf` Nginx configuration. This allowed access to the XML-RPC endpoint, which is a known attack vector for brute-force and DDoS attacks.
🎯 **Impact:** If exploited, attackers with the known token could perform brute-force attacks against WordPress user accounts or launch DDoS attacks against the server.
🔧 **Fix:** The hardcoded secret check and PHP passthrough for `/xmlrpc.php` were entirely removed and replaced with a strict, unconditional `deny all;` block.
✅ **Verification:** Verify by inspecting `server-php/config/conf.d/wordpress.conf` to confirm the presence of the `deny all;` directive under the `/xmlrpc.php` location. Also, the `.jules/sentinel.md` journal is updated.

---
*PR created automatically by Jules for task [8278083936863854360](https://jules.google.com/task/8278083936863854360) started by @Snider*