### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret for XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-04-02 - [CRITICAL] Removed hardcoded XML-RPC bypass token
+**Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` which allowed bypassing the XML-RPC block (`/xmlrpc.php`). This means anyone with the source code could bypass the security control.
+**Learning:** Hardcoded tokens or passwords in Nginx configurations (or any source code) should be strictly avoided. Authentication logic shouldn't rely on static strings in proxy/webserver configurations, as they are often exposed or leak via version control.
+**Prevention:** Remove hardcoded conditional blocks and replace them with unconditional `deny all;` blocks. If bypasses are necessary, they should rely on secure upstream authentication mechanisms instead of hardcoded `$arg_token` matching.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` to bypass the XML-RPC block (`/xmlrpc.php`).
🎯 Impact: Anyone with access to the repository or reverse proxy configuration could seamlessly bypass the XML-RPC block and access the endpoint, leading to possible brute-force amplification attacks. 
🔧 Fix: Removed the hardcoded `$arg_token` conditional matching and unconditionally blocked the endpoint.
✅ Verification: `read_file server-php/config/conf.d/wordpress.conf` confirms the hardcoded string is entirely removed, and the `location = /xmlrpc.php` block correctly `deny all;`.

---
*PR created automatically by Jules for task [8541026814255837437](https://jules.google.com/task/8541026814255837437) started by @Snider*