### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass for XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-29 - [CRITICAL] Nginx Hardcoded Secret Bypass
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was embedded in the Nginx configuration `server-php/config/conf.d/wordpress.conf` to conditionally allow access to `/xmlrpc.php` via `$arg_token`. This acts as a backdoor or a secret bypass for a widely known insecure endpoint (XML-RPC), which can be discovered via file reading, enumeration, or source code leaks.
+**Learning:** Hardcoded secrets in infrastructure configuration (like Nginx) are just as dangerous as secrets in application code. Using `if` conditions in Nginx on arguments like tokens can be extremely prone to leaks and exposes a critical vulnerability.
+**Prevention:** Hardcoded secrets in Nginx configuration files (e.g., `$arg_token` checks) are strictly prohibited. Always replace them with unconditional blocks (`deny all;`) or proper upstream authentication mechanisms.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token `xrpc-9f8e7d6c5b4a` was embedded in the Nginx configuration `server-php/config/conf.d/wordpress.conf` to conditionally allow access to `/xmlrpc.php` via `$arg_token`. This acts as a backdoor or a secret bypass for a widely known insecure endpoint (XML-RPC).
🎯 Impact: This secret can be discovered via file reading, enumeration, or source code leaks. Exploitation grants access to XML-RPC, allowing brute-force and enumeration attacks on WordPress, which is why it should be disabled securely.
🔧 Fix: Removed the `$arg_token` check entirely and replaced the `/xmlrpc.php` location block with an unconditional `deny all;`, along with `access_log off;` and `log_not_found off;` to prevent noisy logs from automated probes. Journaled the critical learning in `.jules/sentinel.md`.
✅ Verification: `cat server-php/config/conf.d/wordpress.conf` shows the new unconditional block for `/xmlrpc.php`.

---
*PR created automatically by Jules for task [7050734121863727466](https://jules.google.com/task/7050734121863727466) started by @Snider*