### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC bypass secret

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - [CRITICAL] Remove Hardcoded XML-RPC Bypass Secret
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was discovered in `server-php/config/conf.d/wordpress.conf` allowing attackers to bypass XML-RPC blocks in Nginx simply by using `?token=xrpc-9f8e7d6c5b4a`.
+**Learning:** Hardcoding secrets like bypass tokens in plain Nginx configuration files is a critical vulnerability. Not only does this compromise security and allow trivial exploitation via simple query arguments, but it also leaks access credentials into source control.
+**Prevention:** Always block inherently risky and deprecated endpoints like `xmlrpc.php` unconditionally using `deny all;`. If remote access is strictly needed, it should rely on robust authentication mechanisms (e.g., proper upstream authorization) and never via unencrypted, static query parameters hardcoded in config files.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC to prevent brute force and DDoS attacks
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was discovered in `server-php/config/conf.d/wordpress.conf` allowing attackers to bypass XML-RPC blocks in Nginx simply by using `?token=xrpc-9f8e7d6c5b4a`.
🎯 **Impact:** Compromises security and allows trivial exploitation via simple query arguments. It also leaks access credentials into source control, enabling brute force and DDoS attacks commonly associated with WordPress XML-RPC.
🔧 **Fix:** Edited `server-php/config/conf.d/wordpress.conf` to replace the conditional logic for `/xmlrpc.php` with an unconditional `deny all;`, and disabled access and not-found logging. This entirely eliminates the hardcoded bypass token. Also recorded this as a critical learning in `.jules/sentinel.md`.
✅ **Verification:** Verified the code changes manually. Nginx config updates are correct and `.jules/sentinel.md` journal entry was created successfully.

---
*PR created automatically by Jules for task [14661169976881936255](https://jules.google.com/task/14661169976881936255) started by @Snider*