### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded token and block XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-27 - [Hardcoded xmlrpc Token]
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was found in `server-php/config/conf.d/wordpress.conf` to allow access to `/xmlrpc.php`.
+**Learning:** Hardcoded secrets in Nginx configuration files can lead to security bypasses and should never be checked into version control.
+**Prevention:** Hardcoded secrets in Nginx configuration files (e.g., `$arg_token` checks) are strictly prohibited and must be replaced with unconditional blocks or proper upstream authentication mechanisms.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration to conditionally allow access to the WordPress `/xmlrpc.php` endpoint. Checking secrets into version control is a major security risk.
🎯 **Impact:** If exploited or leaked, attackers could bypass restrictions to access XML-RPC, leading to potential brute-force or pingback DDoS attacks against the WordPress instance.
🔧 **Fix:** Replaced the conditional bypass with an unconditional `deny all;` for the `/xmlrpc.php` endpoint in `server-php/config/conf.d/wordpress.conf`.
✅ **Verification:** Verified by checking the logic of the Nginx configuration changes. (Docker test of config was unavailable due to environment constraints). Created a journal entry.

---
*PR created automatically by Jules for task [7557940264997697787](https://jules.google.com/task/7557940264997697787) started by @Snider*