### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-24 - [Fix hardcoded XML-RPC secret bypass]
+**Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`) allowing bypass of the XML-RPC endpoint block (`/xmlrpc.php`). This is a critical security risk as hardcoded secrets in version control can be discovered and exploited by attackers.
+**Learning:** Hardcoded secrets, even if intended for internal use or as "tokens", present a major security vulnerability when committed to source control. They create backdoors that bypass intended access controls.
+**Prevention:** Never use hardcoded secrets for authentication or access control in configuration files or code. Use environment variables or robust, managed authentication mechanisms instead. Unconditionally block endpoints like XML-RPC if they are not strictly required, and disable logging to prevent log pollution.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`) allowing bypass of the XML-RPC endpoint block (`/xmlrpc.php`). This is a critical security risk as hardcoded secrets in version control can be discovered and exploited by attackers.
🎯 Impact: Attackers could discover the secret in version control and use it to access the XML-RPC endpoint, opening up vectors for brute-force attacks, DDoS (pingback amplification), and other XML-RPC related vulnerabilities.
🔧 Fix: Removed the conditional logic checking for the token and replaced it with an unconditional `deny all;` for the `/xmlrpc.php` location block. Also added `access_log off;` and `log_not_found off;` to prevent log pollution from automated scanners. Added a critical learning to the Sentinel journal.
✅ Verification: Review the changes to `server-php/config/conf.d/wordpress.conf` and confirm the `location = /xmlrpc.php` block contains `deny all;`.

---
*PR created automatically by Jules for task [197216506852045590](https://jules.google.com/task/197216506852045590) started by @Snider*