### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass in XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-08 - [CRITICAL] Hardcoded Secret Bypass in Nginx Configuration
+**Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`) to bypass the XML-RPC block via the `$arg_token` check.
+**Learning:** Checking query string arguments directly in Nginx configuration files with hardcoded values is an insecure pattern found in this codebase. Nginx configurations are often public or easily exposed, leading to secret leaks and unauthorized access bypass.
+**Prevention:** Hardcoded secrets in Nginx configuration files must be strictly prohibited. Endpoints like XML-RPC should be unconditionally blocked or proper upstream authentication mechanisms should be used.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
**🚨 Severity:** CRITICAL
**💡 Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf`. It was used to bypass the block on the `/xmlrpc.php` endpoint via the `$arg_token` check.
**🎯 Impact:** Nginx configurations are often accessible or exposed. A leaked secret token would allow an attacker to bypass security measures and perform brute-force or DDoS attacks against the XML-RPC endpoint, or potentially exploit other XML-RPC vulnerabilities.
**🔧 Fix:** Removed the conditional `$arg_token` check and replaced it with an unconditional `deny all;` for the `/xmlrpc.php` location. Also disabled logging (`access_log off; log_not_found off;`) to prevent log spam from automated scans. Added an entry to `.jules/sentinel.md` to log this critical vulnerability pattern.
**✅ Verification:** Visually inspected `server-php/config/conf.d/wordpress.conf` to ensure the location block correctly denies all access. Attempted to run Nginx syntax check via Docker, but it failed due to system-level constraints. The fix is less than 50 lines and adheres to security best practices.

---
*PR created automatically by Jules for task [14743138963856262215](https://jules.google.com/task/14743138963856262215) started by @Snider*