### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded token bypass for XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - [Remove hardcoded token check for XML-RPC]
+**Vulnerability:** A hardcoded token check (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`) for allowing access to `/xmlrpc.php`. This is a critical security vulnerability as it allows anyone with knowledge of the token to bypass the block and access the endpoint, potentially exposing the application to abuse.
+**Learning:** Hardcoded secrets in configuration files are a common anti-pattern and can be easily discovered by an attacker if the source code or configuration files are exposed. Nginx configuration files should not contain sensitive information.
+**Prevention:** Unconditionally block sensitive endpoints if they are not required, or implement proper authentication mechanisms (e.g., via upstream application or external authentication service) instead of relying on hardcoded tokens in the web server configuration.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally to prevent abuse
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token check (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`) to allow access to `/xmlrpc.php`. This allows anyone with knowledge of the token to bypass the block and access the endpoint, potentially exposing the application to brute-force or DDoS attacks.
🎯 Impact: Attackers who discover the hardcoded token could exploit the XML-RPC endpoint, compromising the security of the application.
🔧 Fix: Removed the hardcoded token check and replaced it with an unconditional `deny all` to prevent any access to `/xmlrpc.php`. A journal entry was also added to document this finding.
✅ Verification: Review the changes in `server-php/config/conf.d/wordpress.conf` to confirm that the `location = /xmlrpc.php` block now only contains `deny all; access_log off; log_not_found off;`.

---
*PR created automatically by Jules for task [5062582356565095931](https://jules.google.com/task/5062582356565095931) started by @Snider*