### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass for XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-14 - [Remove hardcoded secret bypass for XML-RPC]
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was present in `server-php/config/conf.d/wordpress.conf` allowing a bypass for the XML-RPC block (`/xmlrpc.php`). This is a critical vulnerability since hardcoded credentials in configurations can be easily extracted and abused by attackers to bypass security measures.
+**Learning:** Hardcoded secrets and tokens in Nginx configuration files are prone to accidental exposure and create permanent backdoors. The `xmlrpc.php` file is a known attack vector for brute force and amplification attacks in WordPress and should be blocked completely if not strictly required.
+**Prevention:** Never use hardcoded tokens for authentication or bypass mechanisms in Nginx configurations. If access is needed, use upstream authentication (e.g. basic auth with a secure password file) or network-level restrictions, and unconditionally block known vulnerable endpoints.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC entirely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token `xrpc-9f8e7d6c5b4a` was present in `server-php/config/conf.d/wordpress.conf`, allowing an attacker to bypass the block on the notoriously vulnerable `/xmlrpc.php` endpoint. Hardcoded secrets in configurations can be easily extracted and abused.
🎯 Impact: An attacker discovering this token could execute brute-force attacks, DDoS amplification attacks, or otherwise exploit WordPress XML-RPC vulnerabilities.
🔧 Fix: Removed the secret token bypass entirely. Replaced it with an unconditional `deny all;` block for `/xmlrpc.php`, while also disabling access and not_found logging to prevent log spam from malicious probes. Created `.jules/sentinel.md` journal entry.
✅ Verification: Visually verified the Nginx configuration syntax and confirmed the removal of the bypass. Evaluated standard Docker commands (failed due to existing local overlay mount issue).

---
*PR created automatically by Jules for task [3683016528976426921](https://jules.google.com/task/3683016528976426921) started by @Snider*