### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-15 - [CRITICAL] Avoid hardcoded $arg_token checks in Nginx
+**Vulnerability:** A hardcoded `$arg_token = "xrpc-9f8e7d6c5b4a"` check was present in the Nginx configuration to conditionally allow access to `/xmlrpc.php`, acting as a backdoor bypass.
+**Learning:** Hardcoding secrets directly into infrastructure configuration files like Nginx exposes the system to compromise if the configuration is leaked or checked into version control. It defeats centralized secret management and standard authentication mechanisms.
+**Prevention:** Always implement unconditional blocks for deprecated/vulnerable endpoints (e.g., XML-RPC in modern WordPress). If access is strictly required, use proper external authentication mechanisms (e.g., OAuth, SSO, or standard authentication backends) rather than hardcoded query parameter checks.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded secret token (`$arg_token = "xrpc-9f8e7d6c5b4a"`) was present in the Nginx configuration to conditionally allow access to `/xmlrpc.php`. This acted as a backdoor bypass and exposed a hardcoded secret in infrastructure code.
🎯 **Impact:** If the configuration file was leaked, checked into version control, or viewed by unauthorized personnel, it would allow bypassing security restrictions and potentially exploiting deprecated XML-RPC vulnerabilities (e.g., brute force, DDoS) in WordPress.
🔧 **Fix:** Replaced the hardcoded token check with an unconditional `deny all;` block, and disabled logging for the denied requests.
✅ **Verification:** Verify by inspecting `server-php/config/conf.d/wordpress.conf` to ensure the `location = /xmlrpc.php` block strictly denies access. Attempting to access `/xmlrpc.php` on the WordPress service will now always return 403 Forbidden. I have also added a journal entry in `.jules/sentinel.md` noting this finding.

---
*PR created automatically by Jules for task [2440783475841751469](https://jules.google.com/task/2440783475841751469) started by @Snider*