### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-16 - [Hardcoded Authentication Token Bypass in Nginx]
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was stored directly in the Nginx configuration file (`server-php/config/conf.d/wordpress.conf`) to conditionally bypass a block on the `/xmlrpc.php` endpoint.
+**Learning:** Hardcoding secrets directly in configuration files within source control is a critical security vulnerability, as it exposes the bypass mechanism to anyone with repository access. Additionally, passing secret tokens via URL query parameters (`?token=...`) is inherently insecure as they are often logged in access logs, proxies, and browser history.
+**Prevention:** Unconditionally block endpoints like XML-RPC that are known vectors for brute-force and amplification attacks. Never hardcode secrets in source code or configuration files. Rely on established upstream authentication mechanisms.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
This pull request fixes a critical security vulnerability where a hardcoded secret token was present in the Nginx configuration to bypass the block on the WordPress `/xmlrpc.php` endpoint. 

The XML-RPC block has been made unconditional, and the hardcoded secret has been removed. Access logs and not_found logs are also disabled for this blocked endpoint to minimize noise.

---
*PR created automatically by Jules for task [10110459931099642194](https://jules.google.com/task/10110459931099642194) started by @Snider*