### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - [CRITICAL] Nginx Hardcoded Secret in Configuration
+**Vulnerability:** A hardcoded token (`$arg_token = "xrpc-9f8e7d6c5b4a"`) was used in `server-php/config/conf.d/wordpress.conf` to bypass the XML-RPC block, allowing anyone who discovers the config or knows the secret to bypass the intended block.
+**Learning:** Hardcoded secrets in infrastructure configuration files (like Nginx) are just as dangerous as hardcoded secrets in application code, and can bypass intended application-level or routing-level security controls entirely.
+**Prevention:** Nginx configuration files should rely on unconditional blocks, robust authentication schemes (like upstream checks or standard HTTP auth), or environment-injected configurations rather than hardcoded string matching.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was used in `server-php/config/conf.d/wordpress.conf` to bypass the XML-RPC block.
🎯 **Impact:** Anyone who knows or discovers this hardcoded string could bypass intended blocks and interact with `/xmlrpc.php`, potentially enabling DDoS amplification attacks, brute-force attacks, or other exploits against the WordPress instance.
🔧 **Fix:** Replaced the conditional string matching with an unconditional `deny all;` for the `/xmlrpc.php` location. Also disabled `access_log` and `log_not_found` for this block as per memory instructions. Added a journal entry to `.jules/sentinel.md` documenting this learning about hardcoded secrets in infrastructure configuration files.
✅ **Verification:** Verify that `/xmlrpc.php` contains a `deny all;` directive and does not have the `$arg_token` logic.

---
*PR created automatically by Jules for task [7438220394619985680](https://jules.google.com/task/7438220394619985680) started by @Snider*