### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass for xmlrpc.php

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-18 - [CRITICAL] Remove Hardcoded Secret Bypass for XML-RPC
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was found in `server-php/config/conf.d/wordpress.conf` which allowed bypassing the XML-RPC block (`/xmlrpc.php?token=...`).
+**Learning:** Hardcoded secrets in Nginx config files shouldn't be used to protect sensitive endpoints. XML-RPC is a known vector for brute-forcing, DDoS attacks, and other exploitation in WordPress, and should be completely disabled when not strictly needed.
+**Prevention:** Never use hardcoded secrets or bypasses in Nginx configurations. Always enforce strict block rules (e.g. `deny all;`) for high-risk endpoints like `/xmlrpc.php`, and disable access and not-found logging to prevent log flooding.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token (`xrpc-9f8e7d6c5b4a`) was found in `server-php/config/conf.d/wordpress.conf` which allowed bypassing the XML-RPC block via the `token` query parameter.
🎯 Impact: This allows attackers to bypass intended security controls and access the `/xmlrpc.php` endpoint. This endpoint is a known vector for brute-forcing, DDoS amplification, and other WordPress exploits.
🔧 Fix: Removed the hardcoded bypass and replaced it with a strict, unconditional `deny all;` for the `/xmlrpc.php` location. Added a journal entry to `.jules/sentinel.md` to document the learning.
✅ Verification: Tested configuration locally. No tests are available in the repository.

---
*PR created automatically by Jules for task [4251703925869870465](https://jules.google.com/task/4251703925869870465) started by @Snider*