### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass in Nginx xmlrpc config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-16 - [Hardcoded Secret in Nginx XML-RPC configuration]
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was found in `server-php/config/conf.d/wordpress.conf` allowing a bypass to the default block on `xmlrpc.php` access. Anyone who knows this token can access the endpoint.
+**Learning:** Hardcoded secrets in Nginx configuration files provide static, unchangeable credentials that can be discovered in source code. This is worsened by the fact that `server-php/scripts/entrypoint.sh` lacks `envsubst`, meaning variables cannot be dynamically injected at runtime, so developers often resort to hardcoding.
+**Prevention:** Remove hardcoded secrets from configuration files. Unconditionally block endpoints like `xmlrpc.php` (using `deny all;`) or use proper upstream authentication mechanisms instead of hardcoded `$arg_token` checks.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token (`xrpc-9f8e7d6c5b4a`) was found in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`) allowing a bypass to the default block on `xmlrpc.php` access. Anyone who knows this token can access the endpoint.
🎯 Impact: Attackers who discover the hardcoded token can access the WordPress XML-RPC endpoint, which is frequently used for brute-force attacks and DDoS amplification.
🔧 Fix: Removed the hardcoded secret check and unconditionally blocked the `/xmlrpc.php` endpoint using `deny all;`. Also added a journal entry in `.jules/sentinel.md` reflecting on this vulnerability pattern related to the lack of `envsubst` in the entrypoint script.
✅ Verification: An isolated Nginx syntax check using a wrapper configuration confirms the syntax is valid. Code diff shows the bypass logic is completely removed.

---
*PR created automatically by Jules for task [245334405305389580](https://jules.google.com/task/245334405305389580) started by @Snider*