### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret and unconditionally block XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-20 - [Hardcoded Secret in Nginx Config]
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was found in `server-php/config/conf.d/wordpress.conf` to conditionally allow access to `xmlrpc.php`, completely bypassing the intended security block for anyone who discovers the token.
+**Learning:** Hardcoded authentication tokens embedded directly within Nginx configuration files create severe, easily exploitable backdoors and defeat the purpose of endpoint restrictions.
+**Prevention:** Unconditionally block sensitive endpoints (like `xmlrpc.php`) or use robust authentication mechanisms (e.g., proper upstream authorization, mutually authenticated TLS). Never use hardcoded query parameters for security bypasses.

--- a/server-php/config/conf.d/unified.conf
+++ b/server-php/config/conf.d/unified.conf
@@ -20,6 +20,7 @@ map $http_origin $cors_origin {
 # LARAVEL HOST HUB - Apex Domain
 # ============================================
 server {
+    server_tokens off;
     listen 80;
     listen [::]:80;
     server_name host.uk.com www.host.uk.com;
@@ -108,6 +109,7 @@ server {
 # LARAVEL SATELLITES - Subdomains
 # ============================================
 server {
+    server_tokens off;
     listen 80 default_server;
     listen [::]:80 default_server;
     server_name *.host.uk.com;

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -13,6 +13,7 @@ map $http_origin $cors_origin {
 }
 
 server {
+    server_tokens off;
     listen [::]:80 default_server;
     listen 80 default_server;
 
@@ -105,28 +106,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files

--- a/server-php/config/nginx.conf
+++ b/server-php/config/nginx.conf
@@ -3,6 +3,7 @@ upstream php-fpm {
 }
 
 server {
+    server_tokens off;
     listen 80;
     server_name _;
 

--- a/server-php/linuxkit.yml
+++ b/server-php/linuxkit.yml
@@ -156,6 +156,7 @@ files:
       }
 
       http {
+          server_tokens off;
           include /etc/nginx/mime.types;
           default_type application/octet-stream;
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was found in `wordpress.conf`, which acted as a backdoor to bypass the intended block on `/xmlrpc.php`. Additionally, the Nginx version was being broadcasted.
🎯 **Impact:** An attacker who discovered the token could access the WordPress XML-RPC endpoint, facilitating brute-force attacks, DDoS amplification, and potential remote code execution depending on the WordPress version and plugins. Leaking the Nginx version aids attackers in identifying known vulnerabilities for that specific version.
🔧 **Fix:** 
1. Replaced the conditional bypass with an unconditional `deny all;` for `/xmlrpc.php`, while turning off `access_log` and `log_not_found`.
2. Added `server_tokens off;` to `nginx.conf`, `unified.conf`, `wordpress.conf`, and `linuxkit.yml` to suppress the Nginx server version in responses.
✅ **Verification:** Verified Nginx configuration syntax using `nginx -t`. Reviewed all modified configurations to ensure correct application of directives. Extraneous test files were cleaned up.

---
*PR created automatically by Jules for task [8864962518008518134](https://jules.google.com/task/8864962518008518134) started by @Snider*