### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret for XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-16 - [Hardcoded Secret in Nginx XML-RPC Bypass]
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was left in `server-php/config/conf.d/wordpress.conf` allowing a bypass to the XML-RPC block, providing open access to a known vulnerable WordPress endpoint if the secret is discovered.
+**Learning:** Hardcoded secrets in infrastructure configuration files (like Nginx) can bypass application-level security and are often missed by standard application secret scanners if not explicitly configured to check configuration files.
+**Prevention:** Never hardcode secrets in configuration files. If an endpoint needs restriction, rely on standard mechanisms (like blocking outright if legacy, or proper upstream authentication) rather than hardcoded query parameter checks.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration, acting as an authorization bypass for the WordPress `xmlrpc.php` endpoint.
🎯 **Impact:** If an attacker discovered the token, they could bypass the intended block on the XML-RPC endpoint, potentially exposing the application to brute-force attacks, DDoS amplification (pingback attacks), and other known XML-RPC vulnerabilities.
🔧 **Fix:** Replaced the conditional `$arg_token` logic with an unconditional `deny all;` directive. Also disabled access and not_found logging to prevent log flooding.
✅ **Verification:**
1. Check the `server-php/config/conf.d/wordpress.conf` to ensure `location = /xmlrpc.php` contains only `deny all;`, `access_log off;`, and `log_not_found off;`.
2. A syntax check was successfully executed using `nginx -t` with a test configuration wrapper.

---
*PR created automatically by Jules for task [9324265487148187022](https://jules.google.com/task/9324265487148187022) started by @Snider*