### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC bypass secret in Nginx configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-25 - [Remove Hardcoded Secret in Nginx Config]
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was found in `server-php/config/conf.d/wordpress.conf` to bypass an XML-RPC restriction check.
+**Learning:** Hardcoded secrets in configuration files expose sensitive access mechanisms in version control. Attackers who gain access to the repository or configuration can bypass security controls. XML-RPC bypasses via query params (`?token=...`) are also insecure because query parameters are often logged in access logs, potentially leaking the token to monitoring systems or log aggregators.
+**Prevention:** Hardcoded secrets should not be used in Nginx config for authentication bypass. XML-RPC (`/xmlrpc.php`) should be unconditionally blocked by returning `403` or using `deny all;` unless dynamic authentication is properly implemented via upstream.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret token `xrpc-9f8e7d6c5b4a` was stored in `server-php/config/conf.d/wordpress.conf`. It permitted unauthorized users to bypass the XML-RPC block by supplying the token via query parameter (`/xmlrpc.php?token=...`), which also risks exposing the secret in standard access logs.
🎯 Impact: Attackers who extract the secret from source code or logs could perform XML-RPC attacks against WordPress, potentially leading to brute force attacks, DDoS, or enumeration.
🔧 Fix: Removed the hardcoded token check. Replaced the `/xmlrpc.php` logic with an unconditional `deny all;` and disabled `access_log`/`log_not_found`.
✅ Verification: An `nginx -t` check was performed on the updated configuration block and returned successful. The `.jules/sentinel.md` journal has been updated with learning and prevention insights.

---
*PR created automatically by Jules for task [17038499277427369667](https://jules.google.com/task/17038499277427369667) started by @Snider*