### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret for XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-26 - Hardcoded Secret in Nginx Config
+**Vulnerability:** A hardcoded token (`$arg_token = "xrpc-9f8e7d6c5b4a"`) was used to bypass the restriction on the `/xmlrpc.php` endpoint in the Nginx configuration.
+**Learning:** Hardcoded secrets in Nginx configurations can be exposed if the configuration file is leaked or read by unauthorized users. Furthermore, `$arg_token` allows the token to be passed in the URL query string, which means it will be logged in web server access logs, proxies, and browser history, leading to further exposure.
+**Prevention:** Unconditionally block endpoints that should not be accessed, or use proper authentication mechanisms (like HTTP Basic Auth or upstream authentication) instead of hardcoded tokens in Nginx configuration files. Never pass secrets as query arguments.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC entirely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`$arg_token = "xrpc-9f8e7d6c5b4a"`) was used in the Nginx configuration to selectively bypass the restriction on the `/xmlrpc.php` endpoint. Hardcoding secrets in configuration files is a critical security vulnerability, and accepting tokens as query parameters exposes the secret in access logs, proxy servers, and browser histories.
🎯 **Impact:** If the configuration file is read or leaked, or the access logs are viewed, attackers can obtain the token and bypass the security restriction on `xmlrpc.php`. This endpoint is heavily targeted for brute-force attacks and DDoS amplification.
🔧 **Fix:** The hardcoded secret logic was removed entirely, replacing it with an unconditional `deny all;` for the `/xmlrpc.php` location block, along with disabling logging for those requests.
✅ **Verification:** Verified via `nginx -t` that the modified syntax is correct.

*Note: Codebase-specific vulnerability and learning were appended to the Sentinel Journal (`.jules/sentinel.md`).*

---
*PR created automatically by Jules for task [6052185152721933289](https://jules.google.com/task/6052185152721933289) started by @Snider*