### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-27 - [Hardcoded Secret in Nginx Config]
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was discovered in `server-php/config/conf.d/wordpress.conf` to allow bypass of the `/xmlrpc.php` restriction.
+**Learning:** Hardcoding bypass tokens in Nginx configuration files is dangerous as the secret is checked into source control and visible to everyone.
+**Prevention:** Never use `$arg_token = "secret"` checks in Nginx configuration. Completely block vulnerable endpoints (like `/xmlrpc.php`) or implement a robust authentication strategy instead.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity**: CRITICAL

💡 **Vulnerability**: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` allowing a bypass to the `/xmlrpc.php` restrictions.

🎯 **Impact**: Anyone with knowledge of this token (which is checked into source control and visible) could bypass the block and access the XML-RPC endpoint, potentially leading to brute-force attacks, DDoS, or exploitation of XML-RPC vulnerabilities.

🔧 **Fix**: Removed the `$arg_token` check entirely and replaced it with an unconditional `deny all;` for the `/xmlrpc.php` endpoint. Access logging has also been disabled for this location to prevent log flooding. A journal entry was added to `.jules/sentinel.md` documenting the learning.

✅ **Verification**:
- Inspected the Nginx configuration changes.
- Validated configuration syntax using `nginx -t`.

---
*PR created automatically by Jules for task [11836509687134234169](https://jules.google.com/task/11836509687134234169) started by @Snider*