### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-28 - Remove Hardcoded XML-RPC Secret By Default
+**Vulnerability:** A hardcoded secret ('xrpc-9f8e7d6c5b4a') was used in `server-php/config/conf.d/wordpress.conf` to bypass the XML-RPC block (`/xmlrpc.php?token=...`). Hardcoded secrets pose a critical security risk and act as a backdoor.
+**Learning:** In Nginx configs, developers sometimes leave backdoor tokens to bypass security rules during testing, which make it into production. The XML-RPC endpoint in WordPress is a notorious vector for brute-force attacks and DDoS.
+**Prevention:** Completely deny all access to XML-RPC by default using `deny all;`. If access is required, it must use proper upstream authentication or IP allowlisting, not static hardcoded tokens in config files.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC entirely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret ('xrpc-9f8e7d6c5b4a') was used in `server-php/config/conf.d/wordpress.conf` to bypass the XML-RPC block (`/xmlrpc.php?token=...`).
🎯 Impact: Hardcoded secrets pose a critical security risk and act as a backdoor. The XML-RPC endpoint in WordPress is a notorious vector for brute-force attacks and DDoS.
🔧 Fix: Removed the conditional logic and the hardcoded token. Replaced it with an unconditional `deny all;` directive for the `/xmlrpc.php` location.
✅ Verification: Tested the updated Nginx configuration syntax using `nginx -t` with a test wrapper file, which reported success.

---
*PR created automatically by Jules for task [11463409634946344404](https://jules.google.com/task/11463409634946344404) started by @Snider*