### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret in Nginx configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-29 - [CRITICAL] Remove Hardcoded Secret in Nginx Config
+**Vulnerability:** Found a hardcoded bypass token (`xrpc-9f8e7d6c5b4a`) in the Nginx configuration for WordPress (`wordpress.conf`). The configuration allowed access to the sensitive XML-RPC endpoint (`/xmlrpc.php`) if this token was provided in the query string (`?token=...`).
+**Learning:** Nginx configurations must not contain hardcoded secrets or bypass logic. Such logic bypasses proper authentication and, because configuration files are stored in version control, the secret is easily discoverable by anyone with read access to the repository.
+**Prevention:** Instead of using hardcoded tokens in Nginx, sensitive endpoints like XML-RPC should be unconditionally blocked if not in use (`deny all;`). If access is required, it must be protected by standard authentication layers or managed securely without storing secrets in plaintext configurations.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was used in `wordpress.conf` to bypass the XML-RPC block. This exposes a sensitive endpoint and places plaintext secrets into version control.
🎯 Impact: Attackers who discover this token in the repository can abuse the XML-RPC endpoint for brute-forcing, pingback amplification attacks, and other exploitation vectors.
🔧 Fix: Removed the bypass logic completely, replacing it with an unconditional `deny all;` block for `/xmlrpc.php`. Access and not_found logging were also disabled to prevent log spam.
✅ Verification: Tested the isolated Nginx configuration snippet locally using `nginx -t` with a wrapper script to ensure syntax correctness.

---
*PR created automatically by Jules for task [11114214046477902006](https://jules.google.com/task/11114214046477902006) started by @Snider*