### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret and unconditionally block XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-01 - [Block XML-RPC & Remove Hardcoded Token]
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was being used to bypass the restriction on `/xmlrpc.php` in the WordPress Nginx configuration `server-php/config/conf.d/wordpress.conf`.
+**Learning:** Hardcoded credentials acting as a backdoor in configuration files present a critical risk. `xmlrpc.php` is often targeted for DDoS and brute-force attacks and should typically be blocked by default unless absolutely necessary, without using hardcoded tokens in config files.
+**Prevention:** Ensure configurations strictly enforce unconditional denies for administrative or unneeded endpoints. If an endpoint must be conditionally allowed, use dynamic mechanisms (e.g. valid upstream authentication or environment-based dynamic generation) instead of hardcoding static credentials in plain text Nginx blocks.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token `xrpc-9f8e7d6c5b4a` in `server-php/config/conf.d/wordpress.conf` was serving as a backdoor to bypass blocks on `xmlrpc.php`.
🎯 Impact: This endpoint is frequently targeted for brute-force attacks and DDoS amplification. A hardcoded, plaintext token is susceptible to leaks or could have been checked in by mistake, exposing the endpoint to abuse.
🔧 Fix: Removed the conditional check and the hardcoded token entirely, replacing it with an unconditional `deny all;` for `/xmlrpc.php` per security best practices. We also turned off access logs (`access_log off;`) and error logs (`log_not_found off;`) for this location to prevent log stuffing.
✅ Verification: Successfully parsed and validated the new Nginx configuration using `nginx -t` with a test environment wrapper to ensure syntax correctness.

---
*PR created automatically by Jules for task [3791777052584300402](https://jules.google.com/task/3791777052584300402) started by @Snider*