### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+# Sentinel Journal
+## 2024-05-03 - [CRITICAL] Removed Hardcoded XML-RPC Secret Bypass
+**Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in `server-php/config/conf.d/wordpress.conf` allowing a complete bypass to access `/xmlrpc.php`, a known vector for DDoS and brute-force attacks.
+**Learning:** Hardcoded authentication bypasses ("backdoors") in web server configurations are a critical vulnerability pattern. The configuration bypassed the default secure posture (which block XML-RPC) if a specific string matched. This type of secret bypass in configuration management leads to the secret being committed to version control and broadly deployed.
+**Prevention:** Unconditionally block sensitive endpoints like `/xmlrpc.php` in Nginx using `deny all; access_log off; log_not_found off;`. If an endpoint needs legitimate programmatic access, require strong upstream authentication (e.g., OAuth, API keys injected via environment variables) and avoid placing hardcoded tokens in `.conf` files.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in `server-php/config/conf.d/wordpress.conf` allowing a bypass to access `/xmlrpc.php`. This acts as a backdoor that bypasses standard security measures.
🎯 **Impact:** An attacker who discovers the secret token from the open source repository could use it to access the WordPress XML-RPC endpoint. This endpoint is widely known to be used for brute-force attacks against user credentials and participating in distributed denial-of-service (DDoS) attacks.
🔧 **Fix:** Removed the hardcoded conditional token logic. Replaced it with an unconditional block (`deny all; access_log off; log_not_found off;`) for the `/xmlrpc.php` endpoint. Also documented this critical pattern in the Sentinel journal.
✅ **Verification:** Ran `nginx -t` with the updated configuration locally to ensure Nginx configuration syntax is valid.

---
*PR created automatically by Jules for task [16860973126443244703](https://jules.google.com/task/16860973126443244703) started by @Snider*