### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded token in Nginx config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2025-05-05 - [CRITICAL] Fix Hardcoded Nginx Bypass Token for XML-RPC
+
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` allowing a bypass to the default block on `/xmlrpc.php`. This hardcoded secret could be discovered by anyone with read access to the source code, allowing unauthorized access to the XML-RPC endpoint, which is commonly targeted for brute-force and DDoS attacks against WordPress.
+
+**Learning:** Hardcoded tokens or passwords directly in Nginx configurations bypass standard authentication mechanisms and violate the principle of not storing secrets in source control. The token mechanism was likely intended to provide a specific service or administrator access but failed to use secure secret management.
+
+**Prevention:** Never hardcode secrets in Nginx configuration files (e.g., checking `$arg_token`). Endpoints like XML-RPC should be completely disabled (`deny all;`) if unused, or secured using appropriate upstream authentication that relies on proper secret management or standard HTTP Basic Auth, rather than URL query parameters.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC entirely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) in `server-php/config/conf.d/wordpress.conf` allowed bypassing the default Nginx block for `/xmlrpc.php`. This hardcoded secret could be discovered by anyone with source code access, enabling unauthorized XML-RPC access.
🎯 **Impact:** Exposing `/xmlrpc.php` makes the WordPress instance highly susceptible to brute-force credential stuffing and DDoS amplification attacks. Storing secrets in source control allows an attacker to exploit the endpoint and potentially compromise the site.
🔧 **Fix:** Replaced the conditional `$arg_token` check with a strict and unconditional `deny all;` directive, removing the bypass mechanism entirely. Documented the pattern in `.jules/sentinel.md`.
✅ **Verification:** The Nginx syntax was validated successfully with `nginx -t`.

---
*PR created automatically by Jules for task [15390966242903657877](https://jules.google.com/task/15390966242903657877) started by @Snider*