### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret in Nginx config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Hardcoded Secret in Nginx XML-RPC configuration
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration file `server-php/config/conf.d/wordpress.conf` to allow access to the `/xmlrpc.php` endpoint. This could allow an attacker who discovers the token to execute XML-RPC attacks against the WordPress installation.
+**Learning:** Hardcoding secrets in infrastructure configuration files like Nginx is a vulnerability. These files are typically tracked in version control, making the secret visible to anyone with access to the repository, and environment variable substitution is not always used natively by Nginx.
+**Prevention:** Remove hardcoded secrets from configuration files. Access to administrative or risky endpoints like XML-RPC should be blocked entirely if unused, or protected by standard authentication mechanisms (e.g., HTTP Basic Auth managed securely, or OAuth) instead of simple token query parameters.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        access_log off;
+        log_not_found off;
+        deny all;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration file `server-php/config/conf.d/wordpress.conf` to allow bypass of restrictions to the `/xmlrpc.php` endpoint. This exposes a vector for XML-RPC attacks if the token is discovered via version control or accidental exposure.
🎯 **Impact**: An attacker who discovers the token could execute brute force or DDoS attacks against the WordPress installation via the XML-RPC endpoint.
🔧 **Fix**: Removed the `$arg_token` check containing the secret and unconditionally blocked access to `/xmlrpc.php` (`deny all;`). Logging for this endpoint was also disabled to prevent log spam. Additionally, created a record in the Sentinel Journal (`.jules/sentinel.md`) as a learning for the team.
✅ **Verification**: Verified using `nginx -t` that the updated `wordpress.conf` syntax is valid.

---
*PR created automatically by Jules for task [1783361184480072307](https://jules.google.com/task/1783361184480072307) started by @Snider*