### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret and block xmlrpc

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-08 - [Hardcoded Secret and XML-RPC Bypass]
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was found in the `server-php/config/conf.d/wordpress.conf` file, which was used to bypass the blocking of `/xmlrpc.php`.
+**Learning:** Hardcoded credentials or tokens should never be stored in configuration files or code. It introduces a critical vulnerability where an attacker gaining access to the config or code would instantly compromise the system. Additionally, XML-RPC is largely obsolete in modern WordPress and an attack vector for brute force and DDoS.
+**Prevention:** Do not hardcode secrets in source files. Unconditionally block legacy and high-risk endpoints like `/xmlrpc.php` (`deny all;`). If access is required, rely on robust, dynamic authentication mechanisms.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `server-php/config/conf.d/wordpress.conf` file contained a hardcoded secret token (`xrpc-9f8e7d6c5b4a`) used to bypass the restriction on the `/xmlrpc.php` endpoint.
🎯 Impact: If the source code or configuration files were exposed, an attacker could extract the token and access the `/xmlrpc.php` endpoint, which is a known vector for brute force and DDoS attacks against WordPress.
🔧 Fix: Removed the conditional logic checking the token, and replaced it with a blanket `deny all;` directive to completely block access to `/xmlrpc.php`. Also ensured that logging (`access_log` and `log_not_found`) is disabled for this endpoint to prevent log bloat.
✅ Verification: An nginx syntax check (`nginx -t`) was run in an isolated test configuration wrapper to ensure no syntactical errors were introduced.

---
*PR created automatically by Jules for task [11402150755310997405](https://jules.google.com/task/11402150755310997405) started by @Snider*