### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass for XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2025-05-10 - [CRITICAL] XML-RPC Hardcoded Secret Bypass in Nginx Configuration
+**Vulnerability:** The Nginx configuration for WordPress (`server-php/config/conf.d/wordpress.conf`) contained a hardcoded secret token (`xrpc-9f8e7d6c5b4a`) that bypassed the default restriction on the `/xmlrpc.php` endpoint.
+**Learning:** Hardcoding secrets or bypass tokens in web server configurations (like Nginx `if` statements checking `$arg_token`) creates a static backdoor. It defeats the purpose of disabling vulnerable endpoints and could be easily discovered by attackers analyzing source code or observing URL patterns.
+**Prevention:** Remove unconditional endpoints that should be disabled entirely instead of providing hidden "secret" bypasses. If conditional access is required, implement properly authenticated mechanisms or IP whitelisting rather than static query parameter tokens in configuration files.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) in the Nginx WordPress configuration bypassed the intended block on the `/xmlrpc.php` endpoint. 
🎯 Impact: Attackers who discovered this static token (either through repository access, leaks, or brute force) could bypass the block and perform XML-RPC attacks (e.g., brute-forcing credentials, pingback DDoS attacks) against the WordPress instance.
🔧 Fix: Removed the conditional check containing the hardcoded secret and replaced it with an unconditional `deny all;` block for the `/xmlrpc.php` endpoint, with logging disabled to prevent log pollution.
✅ Verification: Tested the Nginx configuration syntax with `nginx -t` to ensure it is correct and valid. Verified there are no regressions.

---
*PR created automatically by Jules for task [3746873595116924448](https://jules.google.com/task/3746873595116924448) started by @Snider*