### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass for xmlrpc.php

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-11 - [Hardcoded XML-RPC Secret Bypass]
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was embedded in an Nginx `wordpress.conf` file to conditionally bypass a block on `/xmlrpc.php` via a query parameter check (`$arg_token = "..."`).
+**Learning:** Hardcoded authentication logic in load balancer or web server configurations often goes unnoticed during standard codebase security scans since it resides outside the main application logic, yet it provides a direct, unauthenticated back-door to potentially vulnerable endpoints.
+**Prevention:** Avoid embedding any secrets or authentication bypass logic within infrastructure or web server configurations. If an endpoint must be blocked, use an unconditional `deny all;`. If access is required, rely on robust, standard authentication mechanisms (like OAuth or mutual TLS) at the application or edge layer rather than hardcoded query parameter checks.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC completely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was embedded in `server-php/config/conf.d/wordpress.conf` to allow bypassing the block on the `/xmlrpc.php` endpoint using a query parameter (`?token=xrpc-9f8e7d6c5b4a`).
🎯 Impact: Anyone who discovers or leaks this hardcoded token can bypass the intended restrictions and access the XML-RPC endpoint, which is frequently targeted for brute-force attacks, DDoS amplification, and potential exploitation of legacy WordPress vulnerabilities.
🔧 Fix: Removed the custom token check logic and replaced it with a complete, unconditional block (`deny all;`). Also disabled `access_log` and `log_not_found` for the endpoint to reduce log spam from automated scanners.
✅ Verification: Ran `nginx -t` with a test wrapper to verify the syntax of the updated `wordpress.conf`. The syntax is correct and the endpoint is securely blocked.

---
*PR created automatically by Jules for task [16247710876232573678](https://jules.google.com/task/16247710876232573678) started by @Snider*