### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC bypass token

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-12 - [Hardcoded XML-RPC Bypass Token]
+**Vulnerability:** A hardcoded token (`$arg_token = "xrpc-9f8e7d6c5b4a"`) was used in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`) to bypass the block on `/xmlrpc.php`.
+**Learning:** Hardcoded secrets in Nginx configuration files via `$arg_token` or similar variables create a static backdoor that is easily discoverable and exploitable.
+**Prevention:** Remove unconditional bypasses based on static tokens. Use robust upstream authentication mechanisms or keep endpoints unconditionally blocked if not needed.

--- a/server-php/config/conf.d/unified.conf
+++ b/server-php/config/conf.d/unified.conf
@@ -29,6 +29,8 @@ server {
 
     client_max_body_size 64M;
 
+    server_tokens off;
+
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
@@ -116,6 +118,8 @@ server {
     index index.php;
 
     client_max_body_size 64M;
+
+    server_tokens off;
 
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -41,6 +41,8 @@ server {
 
     client_max_body_size 64M;
 
+    server_tokens off;
+
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
@@ -105,28 +107,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files

--- a/server-php/config/nginx.conf
+++ b/server-php/config/nginx.conf
@@ -11,6 +11,8 @@ server {
 
     client_max_body_size 64M;
 
+    server_tokens off;
+
     # Security headers
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;

--- a/server-php/linuxkit.yml
+++ b/server-php/linuxkit.yml
@@ -159,6 +159,8 @@ files:
           include /etc/nginx/mime.types;
           default_type application/octet-stream;
 
+          server_tokens off;
+
           log_format main '$remote_addr - $remote_user [$time_local] "$request" '
                           '$status $body_bytes_sent "$http_referer" '
                           '"$http_user_agent" "$http_x_forwarded_for"';


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token (`$arg_token = "xrpc-9f8e7d6c5b4a"`) was used in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`) to bypass the block on `/xmlrpc.php`.
🎯 Impact: An attacker could discover this hardcoded token and bypass the intended security restrictions on `xmlrpc.php`, allowing them to execute XML-RPC methods, which are often used for brute-force attacks and DDoS amplification against WordPress sites.
🔧 Fix: Removed the conditional logic and hardcoded token. Unconditionally deny access to `/xmlrpc.php`. Additionally, added `server_tokens off;` to all Nginx configuration files as a defense-in-depth security enhancement to prevent Nginx version disclosure.
✅ Verification: Tested Nginx configurations using a custom test wrapper and `nginx -t`. Checked that no other config files rely on this token. Recorded the vulnerability pattern in the Sentinel journal.

---
*PR created automatically by Jules for task [17318912543978070233](https://jules.google.com/task/17318912543978070233) started by @Snider*