### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XML-RPC hardcoded secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-14 - [XML-RPC Hardcoded Secret Bypass]
+**Vulnerability:** A hardcoded secret (`xrpc-9f8e7d6c5b4a`) in `server-php/config/conf.d/wordpress.conf` was being used to bypass the XML-RPC block via the `?token=` parameter.
+**Learning:** Hardcoded secrets in Nginx configuration files can lead to security bypasses if discovered, as they provide a permanent backdoor that cannot be easily rotated.
+**Prevention:** Always use unconditional blocks (`deny all;`) for dangerous endpoints, or implement proper upstream authentication without relying on hardcoded parameter checks in web server configs.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret (`xrpc-9f8e7d6c5b4a`) in `server-php/config/conf.d/wordpress.conf` was being used to bypass the XML-RPC block via the `?token=` parameter.
🎯 Impact: An attacker who discovers this hardcoded token could bypass the intended restriction and access `/xmlrpc.php`, potentially performing brute-force or DDoS amplification attacks.
🔧 Fix: Replaced the conditional bypass with an unconditional `deny all;` block. Also disabled logging for this endpoint.
✅ Verification: The Nginx configuration syntax was verified using `nginx -t` with a test wrapper. Docker build attempts were evaluated.

---
*PR created automatically by Jules for task [4074382647077599535](https://jules.google.com/task/4074382647077599535) started by @Snider*