### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - [CRITICAL] Fix hardcoded XML-RPC secret bypass
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` allowing a bypass to the default block on `/xmlrpc.php`.
+**Learning:** Hardcoding secrets directly in Nginx configurations allows anyone with access to the source code to bypass intended security controls. Secrets should not be embedded in `.conf` files.
+**Prevention:** Never use static strings to bypass security controls in Nginx configurations. Instead, rely on proper authentication mechanisms, block vulnerable endpoints unconditionally when possible, or inject necessary tokens through secure environment variables at runtime if an exception is truly needed.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally for security
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`), allowing a bypass to the default block on `/xmlrpc.php`. This allows anyone who views the source code to easily execute XML-RPC attacks (brute force, DDoS).
🎯 **Impact:** Exposes the WordPress installation to unauthorized XML-RPC access, leading to potential brute-force attacks and DDoS amplification.
🔧 **Fix:** Removed the hardcoded secret and unconditionally blocked access to `/xmlrpc.php` using `deny all;`, along with turning off access and error logging for this endpoint.
✅ **Verification:** Verified syntax correctness using isolated Nginx testing (`nginx -t`).

---
*PR created automatically by Jules for task [14739949436688366152](https://jules.google.com/task/14739949436688366152) started by @Snider*