### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XML-RPC hardcoded secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-16 - [CRITICAL] Remove Hardcoded XML-RPC Secret Bypass
+**Vulnerability:** A hardcoded token (`$arg_token = "xrpc-9f8e7d6c5b4a"`) was present in `server-php/config/conf.d/wordpress.conf`, acting as a backdoor to bypass the default block on `/xmlrpc.php`.
+**Learning:** Hardcoding secrets directly in configuration files exposes them in version control and creates backdoor access. `xmlrpc.php` is a frequent attack vector and should be denied unconditionally unless explicitly required by a legacy service, rather than protected with static tokens.
+**Prevention:** Unconditionally block high-risk endpoints like `/xmlrpc.php` (`deny all;`) and disable logging for them to prevent log spam. Never hardcode tokens or credentials in Nginx configurations.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC entirely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`$arg_token = "xrpc-9f8e7d6c5b4a"`) was present in `server-php/config/conf.d/wordpress.conf`, acting as a backdoor to bypass the default block on `/xmlrpc.php`. This allows anyone with the token to access the XML-RPC endpoint, which is a known vector for brute-force attacks and DDoS.
🎯 **Impact:** If an attacker discovers the token (e.g., from source code exposure, proxy logs, or misconfiguration), they can bypass the intended restrictions and launch attacks against the WordPress installation.
🔧 **Fix:** Replaced the conditional bypass with an unconditional block (`deny all;`) and disabled `access_log` and `log_not_found` to reduce log spam from bots.
✅ **Verification:** Ran `nginx -t` with the updated configuration snippet. No syntax errors were found.

---
*PR created automatically by Jules for task [15815980236766657837](https://jules.google.com/task/15815980236766657837) started by @Snider*