### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret for XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-18 - [Fix hardcoded secret for XML-RPC bypass]
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`) to bypass the XML-RPC block (`/xmlrpc.php`).
+**Learning:** Hardcoding secrets or bypass tokens directly in configuration files exposes the application to unauthorized access if the configuration is leaked or accessible. Nginx logic is often used to implement these backdoors.
+**Prevention:** Avoid using hardcoded tokens in configuration files. If an endpoint needs to be restricted, apply proper authentication mechanisms or unconditionally block access (`deny all;`) if it is not required by legitimate clients.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was embedded in the Nginx configuration to selectively bypass the block on the WordPress `/xmlrpc.php` endpoint.
🎯 **Impact:** If this configuration file is leaked or if an attacker discovers the token through timing attacks or brute-force (unlikely given length but possible), they can gain unrestricted access to the XML-RPC interface. This interface is notoriously used for brute-forcing credentials and performing DDoS attacks.
🔧 **Fix:** Replaced the conditional `$arg_token` check with an unconditional `deny all;` directive for the `/xmlrpc.php` location. Also disabled access and not found logging for this endpoint to reduce noise.
✅ **Verification:** Verified Nginx configuration syntax is valid using `nginx -t`. Included the finding in the Sentinel journal.

---
*PR created automatically by Jules for task [1042475046750060320](https://jules.google.com/task/1042475046750060320) started by @Snider*