### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC bypass token

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+## 2024-05-19 - [Initialization]
+**Vulnerability:** N/A
+**Learning:** N/A
+**Prevention:** N/A
+
+## 2026-05-19 - [Fix hardcoded XML-RPC secret bypass]
+**Vulnerability:** A hardcoded authentication token bypass was found for `/xmlrpc.php` allowing potentially malicious XML-RPC access by using `?token=xrpc-9f8e7d6c5b4a`.
+**Learning:** Implementing security bypasses with hardcoded tokens in Nginx configuration directly undermines defense in depth.
+**Prevention:** Never use hardcoded secrets in Nginx config files. If endpoints need protection or conditional access, use proper upstream authentication or block completely (`deny all;`) if unneeded.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token (`xrpc-9f8e7d6c5b4a`) in `server-php/config/conf.d/wordpress.conf` allowed bypassing the XML-RPC block. This is a severe security risk as it could allow attackers to bypass intended restrictions using the hardcoded credential, potentially opening the WordPress site up to XML-RPC brute forcing or exploitation.
🎯 Impact: Attackers who find the hardcoded string could use it to authenticate and access the XML-RPC endpoint, leading to unauthorized actions or denial of service on the site.
🔧 Fix: Replaced the conditional bypass with a strict `deny all;` directive and disabled logging for that location to minimize disk usage from automated scans.
✅ Verification: Nginx configuration syntax was verified locally using `nginx -t`. The `.jules/sentinel.md` journal was updated to record the pattern for future prevention.

---
*PR created automatically by Jules for task [8462904739321433562](https://jules.google.com/task/8462904739321433562) started by @Snider*