### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret for XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - [Remove Hardcoded Secret in Nginx Config for XML-RPC Bypass]
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was embedded directly into the Nginx configuration file (`server-php/config/conf.d/wordpress.conf`) to conditionally bypass a block on `/xmlrpc.php` and allow access.
+**Learning:** Hardcoded secrets in infrastructure configuration files (like Nginx configs) create critical security risks because they are checked into version control, making them accessible to anyone with repository access. Furthermore, they are difficult to rotate securely and uniformly.
+**Prevention:** Never use hardcoded secrets in Nginx configuration files (e.g., using `$arg_token` checks). Access control should rely on secure upstream authentication mechanisms, or problematic endpoints like `xmlrpc.php` should be unconditionally blocked if they are not strictly necessary.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC completely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token `xrpc-9f8e7d6c5b4a` was embedded directly into the Nginx configuration file (`server-php/config/conf.d/wordpress.conf`) to conditionally bypass a block on `/xmlrpc.php` and allow access. Hardcoded secrets in infrastructure configuration files create critical security risks as they are checked into version control and difficult to rotate securely.
🎯 Impact: Attackers who find the hardcoded token in the source code can bypass the XML-RPC block, opening up the WordPress site to potential brute-force or amplification attacks typically associated with `xmlrpc.php`.
🔧 Fix: Replaced the conditional bypass with an unconditional `deny all;` block for the `/xmlrpc.php` endpoint. Documented the learning in the Sentinel journal.
✅ Verification: Tested the Nginx configuration syntax with `nginx -t` using a wrapper configuration to ensure the syntax remains correct after the modification.

---
*PR created automatically by Jules for task [9631897619354816255](https://jules.google.com/task/9631897619354816255) started by @Snider*