### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2024-05-22 - [CRITICAL] Fix hardcoded XML-RPC secret bypass
+
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was used in `server-php/config/conf.d/wordpress.conf` to conditionally bypass the `deny` rule for `xmlrpc.php`. This allows anyone with the token to access the XML-RPC endpoint.
+
+**Learning:** Hardcoding secrets like bypass tokens in server configuration files makes them vulnerable to exposure through repository read access, config leaks, or accidental publishing. It overrides default security measures relying on environment variables or external authentication mechanisms.
+
+**Prevention:** Never commit hardcoded secrets, passwords, or bypass tokens in configuration files. Use robust authentication methods (like OAuth, JWT) or restrict access based on secure, managed infrastructure like internal networks or VPNs, instead of simple shared secrets in Nginx configuration.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token `xrpc-9f8e7d6c5b4a` was present in the Nginx configuration to selectively bypass the block on `xmlrpc.php`.
🎯 Impact: Anyone discovering or knowing this token could access the WordPress XML-RPC endpoint, opening up risks of brute-force attacks or DDoS. Hardcoding secrets in config files exposes them easily.
🔧 Fix: Replaced the conditional bypass with an unconditional `deny all;`, and disabled `access_log` and `log_not_found` for the endpoint.
✅ Verification: `nginx -t` confirms the syntax is still valid. The configuration now blocks all access to `/xmlrpc.php`. Also added an entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [13660479524076291509](https://jules.google.com/task/13660479524076291509) started by @Snider*