### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-23 - [CRITICAL] Fix hardcoded XML-RPC secret bypass
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` allowing a bypass to access the `/xmlrpc.php` endpoint even though it was intended to be blocked by default.
+**Learning:** Hardcoding secrets or bypass tokens directly in server configuration files creates a persistent and easily discoverable backdoor. It violates the defense-in-depth principle by enabling potential remote code execution or enumeration attacks if the XML-RPC endpoint is vulnerable.
+**Prevention:** Always unconditionally block deprecated or risky endpoints like XML-RPC in production setups unless strictly required. If access is required, implement proper authentication/authorization mechanisms and never hardcode secrets or tokens in configuration files.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC entirely for security
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration `server-php/config/conf.d/wordpress.conf`. This token allowed an attacker to bypass the intended block on the `/xmlrpc.php` endpoint.
🎯 **Impact:** If the underlying WordPress application has XML-RPC enabled and contains vulnerabilities, an attacker discovering this static token could exploit those vulnerabilities (such as brute-force attacks or pingback amplification) despite the general restriction. Hardcoded secrets are a severe violation of defense-in-depth principles.
🔧 **Fix:** Replaced the token check logic with an unconditional `deny all;` for the `/xmlrpc.php` location. Additionally, turned off `access_log` and `log_not_found` for this endpoint to prevent log bloat from automated scanners. Created `.jules/sentinel.md` with a journal entry recording this issue.
✅ **Verification:**
1. Check `server-php/config/conf.d/wordpress.conf` and verify the `$arg_token` logic is removed.
2. Verified Nginx configuration syntax using `nginx -t` locally with a minimal wrapper.
3. Check `.jules/sentinel.md` for the documented learning.

---
*PR created automatically by Jules for task [10643035242124320569](https://jules.google.com/task/10643035242124320569) started by @Snider*