### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret for XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [CRITICAL] Fix hardcoded secret for XML-RPC bypass
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was used as an arg parameter to bypass the default block on `/xmlrpc.php` in the `wordpress.conf` Nginx configuration.
+**Learning:** Hardcoded secrets in Nginx configuration files expose endpoints to unauthorized access, especially when configuration files are version controlled. Any attacker knowing the token could access the XML-RPC endpoint, potentially launching brute-force attacks or exploiting XML-RPC vulnerabilities.
+**Prevention:** Always use proper upstream authentication or use environment variables/secret injection instead of hardcoding secrets in configuration files. If an endpoint is meant to be disabled for security reasons, disable it unconditionally without backdoors.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was used as an arg parameter to bypass the default block on `/xmlrpc.php` in the `wordpress.conf` Nginx configuration.
🎯 **Impact:** Hardcoded secrets in version control expose endpoints to unauthorized access. An attacker knowing the token could access the XML-RPC endpoint, potentially launching brute-force attacks or exploiting XML-RPC vulnerabilities on the WordPress instance.
🔧 **Fix:** Replaced the conditional bypass with an unconditional block (`deny all;`, `access_log off;`, `log_not_found off;`).
✅ **Verification:**
1. Ran `sudo nginx -t` against the modified `wordpress.conf` configuration with an isolated Nginx wrapper. Syntax validation passed successfully.
2. Verified the file no longer contains the hardcoded token.

---
*PR created automatically by Jules for task [7528224744078646873](https://jules.google.com/task/7528224744078646873) started by @Snider*