### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded token bypass for XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-25 - [Fix hardcoded token bypass for XML-RPC]
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was used to bypass the default block on `/xmlrpc.php` in Nginx configuration. This allows anyone with the token to access the potentially vulnerable XML-RPC endpoint.
+**Learning:** Hardcoding secrets (like `$arg_token` checks) in Nginx configurations provides a false sense of security and exposes endpoints if the configuration or the secret is leaked.
+**Prevention:** Unconditionally block known-vulnerable endpoints (like `/xmlrpc.php`) or use proper authentication mechanisms like basic auth or an upstream authentication provider instead of hardcoded URL parameters.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was used in `server-php/config/conf.d/wordpress.conf` to conditionally bypass the block on the `/xmlrpc.php` endpoint. This could allow unauthorized access to the potentially vulnerable WordPress XML-RPC API if the configuration or the token were leaked.
🎯 **Impact:** If exploited, attackers could use the XML-RPC endpoint for brute-force attacks, DDoS amplification, or potentially remote code execution (depending on other WordPress vulnerabilities).
🔧 **Fix:** Removed the `$arg_token` check completely and replaced it with an unconditional block (`deny all;`). Also disabled `access_log` and `log_not_found` for this endpoint to reduce log noise.
✅ **Verification:** Verified Nginx syntax locally using a wrapper script (`sudo nginx -t -c test_nginx.conf`).
📝 **Journal:** Added a critical learning entry to `.jules/sentinel.md` regarding the danger of hardcoding secrets in Nginx configuration.

---
*PR created automatically by Jules for task [8475934240804117209](https://jules.google.com/task/8475934240804117209) started by @Snider*