### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix hardcoded XML-RPC secret

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-26 - Hardcoded secret in Nginx config for XML-RPC bypass
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was found in `server-php/config/conf.d/wordpress.conf` to bypass the XML-RPC block (`/xmlrpc.php`).
+**Learning:** Hardcoded secrets in infrastructure configuration files (like Nginx) can be easily overlooked but expose endpoints to brute-force and DDoS attacks if leaked, as they are not subject to standard application-level secret management.
+**Prevention:** Never hardcode secrets in configuration files. If an endpoint is meant to be blocked or restricted, block it unconditionally or use standard authentication mechanisms (like mutual TLS or standard basic auth tied to a secure identity provider), and ensure blocked endpoints disable logging (`access_log off; log_not_found off;`) to prevent log spoofing/filling.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was discovered in `server-php/config/conf.d/wordpress.conf` allowing a bypass to the XML-RPC block (`/xmlrpc.php`).
🎯 **Impact:** Hardcoded secrets in infrastructure configuration files expose endpoints to brute-force and DDoS attacks if leaked (especially in public or shared repositories), as they bypass application-level secret management. `/xmlrpc.php` is a known vector for brute-forcing WordPress credentials.
🔧 **Fix:** Replaced the hardcoded secret and token logic with an unconditional block (`deny all; access_log off; log_not_found off;`) for `/xmlrpc.php`. Also added the incident to the Sentinel journal for reference.
✅ **Verification:** Verified that the Nginx configuration syntax is valid using `nginx -t`. No temporary testing artifacts were committed.

---
*PR created automatically by Jules for task [4381876433440346141](https://jules.google.com/task/4381876433440346141) started by @Snider*