### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC bypass secret

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-27 - [Hardcoded XML-RPC Bypass Secret in Nginx]
+**Vulnerability:** Found a hardcoded authentication token (`$arg_token = "xrpc-9f8e7d6c5b4a"`) in `server-php/config/conf.d/wordpress.conf` used to bypass the block on `/xmlrpc.php`. This constitutes a backdoor and allows anyone with the token to access a potentially vulnerable XML-RPC endpoint.
+**Learning:** Hardcoding secrets directly in Nginx configuration files is dangerous as the configuration files are often committed to version control. Furthermore, a shared static secret is not a secure mechanism for authentication.
+**Prevention:** Remove the hardcoded token check and unconditionally deny access (`deny all;`) to `/xmlrpc.php`. If access is legitimately needed, it should be authenticated via proper upstream authentication mechanisms, not Nginx query parameter checks with static strings.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret (`$arg_token = "xrpc-9f8e7d6c5b4a"`) was found in `server-php/config/conf.d/wordpress.conf`. It acted as a backdoor, allowing anyone with the token to bypass the block on the `/xmlrpc.php` endpoint.
🎯 Impact: This allowed unauthenticated, hidden access to an endpoint commonly targeted for brute force and DDoS attacks.
🔧 Fix: Removed the hardcoded secret check and replaced it with an unconditional `deny all;` for the `/xmlrpc.php` location. Also turned off access and not_found logging to prevent log pollution from automated scanners. Created a `.jules/sentinel.md` journal entry.
✅ Verification: Tested the updated Nginx configuration syntax using `nginx -t` and verified it passes.

---
*PR created automatically by Jules for task [9753999973573904039](https://jules.google.com/task/9753999973573904039) started by @Snider*