### PR TITLE
🛡️ Sentinel: [security improvement] Disable Nginx server tokens

### DIFF
--- a/server-php/config/conf.d/unified.conf
+++ b/server-php/config/conf.d/unified.conf
@@ -23,6 +23,7 @@ server {
     listen 80;
     listen [::]:80;
     server_name host.uk.com www.host.uk.com;
+    server_tokens off;
 
     root /app/public;
     index index.php;
@@ -111,6 +112,7 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
     server_name *.host.uk.com;
+    server_tokens off;
 
     root /app/public;
     index index.php;

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -15,6 +15,7 @@ map $http_origin $cors_origin {
 server {
     listen [::]:80 default_server;
     listen 80 default_server;
+    server_tokens off;
 
     # Only accept subdomain traffic (*.host.uk.com), not apex domain
     # The apex domain (host.uk.com) should route to Host Hub (Laravel)

--- a/server-php/config/nginx.conf
+++ b/server-php/config/nginx.conf
@@ -5,6 +5,7 @@ upstream php-fpm {
 server {
     listen 80;
     server_name _;
+    server_tokens off;
 
     root /var/www/html;
     index index.php;

--- a/server-php/linuxkit.yml
+++ b/server-php/linuxkit.yml
@@ -158,6 +158,7 @@ files:
       http {
           include /etc/nginx/mime.types;
           default_type application/octet-stream;
+          server_tokens off;
 
           log_format main '$remote_addr - $remote_user [$time_local] "$request" '
                           '$status $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
## Security Enhancement

Added `server_tokens off;` to all Nginx configuration files across the `server-php` ecosystem.

**Motivation:**
By default, Nginx emits its exact version number in the `Server` HTTP response header and on standard error pages. Exposing this information provides potential attackers with reconnaissance data about the stack, making it easier to identify known vulnerabilities for a specific version. Disabling it is a standard security best practice.

**Changes made:**
- Added `server_tokens off;` to the `server` block in `server-php/config/nginx.conf`.
- Added `server_tokens off;` to all `server` blocks in `server-php/config/conf.d/unified.conf`.
- Added `server_tokens off;` to the `server` block in `server-php/config/conf.d/wordpress.conf`.
- Added `server_tokens off;` to the embedded Nginx `http` block in `server-php/linuxkit.yml`.

**Verification:**
Nginx syntax was verified successfully by extracting the configurations, providing mocked requirements, and running `nginx -t`.

---
*PR created automatically by Jules for task [14471980091660097152](https://jules.google.com/task/14471980091660097152) started by @Snider*