### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - [Remove hardcoded XML-RPC secret token]
+**Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in `server-php/config/conf.d/wordpress.conf` to conditionally allow access to `/xmlrpc.php`.
+**Learning:** Hardcoded secrets in infrastructure configuration (like Nginx config) can be leaked through source code access, making the "secret" bypass trivial to discover and exploit for anyone with access to the repo. It's a critical risk.
+**Prevention:** Avoid using hardcoded secrets in Nginx config files (`$arg_token` checks) to gate endpoints. Instead, use unconditional blocks (`deny all;`) or secure, dynamic authentication mechanisms (e.g., standard Auth Request module).

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC entirely for security
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was stored in `server-php/config/conf.d/wordpress.conf` to conditionally allow access to the `/xmlrpc.php` endpoint.
🎯 Impact: Anyone with access to the source code repository or the Nginx config files could discover the bypass token and exploit the notoriously vulnerable XML-RPC endpoint on the WordPress installation, potentially enabling brute-force attacks or DDoS.
🔧 Fix: Replaced the `$arg_token` check logic with an unconditional `deny all;` inside the `/xmlrpc.php` location block, effectively disabling XML-RPC access securely and entirely.
✅ Verification: An Nginx syntax verification using a simulated context within the sandbox passed (`nginx -t -c test_nginx.conf`), confirming the changes are valid and do not introduce server errors. A journal entry has been created in `.jules/sentinel.md` documenting this pattern.

---
*PR created automatically by Jules for task [7861265351686831268](https://jules.google.com/task/7861265351686831268) started by @Snider*