### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass in Nginx config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-31 - [CRITICAL] Fix hardcoded secret bypass in Nginx config
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was discovered in `server-php/config/conf.d/wordpress.conf` allowing a bypass to the blocked `/xmlrpc.php` endpoint.
+**Learning:** Hardcoding secrets directly into source code, specifically in configuration files such as Nginx config files, constitutes a major vulnerability, as they could be easily compromised.
+**Prevention:** Unconditional blocks (`deny all;`) should be utilized for endpoints that are blocked for security purposes. No secrets should be hardcoded within configuration files. Ensure that configuration changes are reviewed strictly for such embedded tokens.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC entirely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token `xrpc-9f8e7d6c5b4a` was discovered in `server-php/config/conf.d/wordpress.conf` allowing a bypass to the blocked `/xmlrpc.php` endpoint.
🎯 Impact: An attacker could discover or find this token and use it to execute arbitrary commands, brute force passwords, and launch DDoS attacks via the XML-RPC endpoint, compromising the application.
🔧 Fix: Replaced the secret checking logic with an unconditional `deny all;` directive, as is best practice for disabled WordPress endpoints.
✅ Verification: Tested the Nginx configuration manually using `nginx -t`. No syntax errors found.

---
*PR created automatically by Jules for task [8699804109252243453](https://jules.google.com/task/8699804109252243453) started by @Snider*