### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC bypass token

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-01 - [Hardcoded XML-RPC Secret Bypass]
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was present in `server-php/config/conf.d/wordpress.conf` which allowed bypassing the XML-RPC block.
+**Learning:** Hardcoding secrets or bypass tokens in server configuration files creates a critical vulnerability.
+**Prevention:** Remove hardcoded secrets from configuration files and unconditionally block sensitive endpoints like XML-RPC unless explicitly required and secured with a proper mechanism.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC entirely for security
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token `xrpc-9f8e7d6c5b4a` was present in `server-php/config/conf.d/wordpress.conf` which allowed bypassing the XML-RPC block.
🎯 Impact: Attackers who discover or guess the hardcoded token could gain unauthorized access to the WordPress XML-RPC endpoint, leading to potential credential brute-forcing, content modification, or participation in DDoS amplification attacks.
🔧 Fix: Removed the hardcoded `$arg_token` bypass logic and unconditionally blocked `/xmlrpc.php` with `deny all`. Also disabled access and not found logging for the blocked endpoint. Added a critical learning entry to the Sentinel journal.
✅ Verification: Tested the Nginx configuration syntax with `nginx -t` using a temporary wrapper. Verified changes are restricted only to the `xmlrpc.php` block and do not impact other Nginx functionalities.

---
*PR created automatically by Jules for task [17376735347116682890](https://jules.google.com/task/17376735347116682890) started by @Snider*