### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass in XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-02 - [CRITICAL] Hardcoded Secret Bypass in XML-RPC configuration
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was present in the Nginx `wordpress.conf` configuration file, allowing anyone with the token to bypass the XML-RPC block and access the `/xmlrpc.php` endpoint.
+**Learning:** Hardcoded secrets in infrastructure configuration files like Nginx can completely undermine application-level security and are often overlooked in standard code reviews.
+**Prevention:** Always use unconditional blocks (`deny all;`) for disabled endpoints in Nginx. If authentication is necessary, use properly configured upstream mechanisms or securely managed environment variables, never plain-text tokens in source control.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC completely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded plain-text token (`xrpc-9f8e7d6c5b4a`) was left in the Nginx `wordpress.conf` file, which allowed anyone providing this token via query parameter to bypass the XML-RPC block and access the `/xmlrpc.php` endpoint. Hardcoded secrets in infrastructure configuration undermine security and are a significant risk.
🎯 Impact: Attackers who discovered the token (which could easily happen through source code leaks or exposure) could exploit the `/xmlrpc.php` endpoint for brute-force attacks on WordPress user passwords, DDoS amplification attacks, or potentially other WordPress XML-RPC specific vulnerabilities, completely bypassing the intended access restrictions.
🔧 Fix: Replaced the conditional bypass logic (`$arg_token = "xrpc-9f8e7d6c5b4a"`) with an unconditional `deny all;` directive, and disabled access logging and `log_not_found` for the endpoint to minimize log bloat. Documented this finding in the Sentinel journal `.jules/sentinel.md`.
✅ Verification: An `nginx -t` test on the updated `wordpress.conf` was performed using a wrapper configuration to ensure syntax correctness, which completed successfully.

---
*PR created automatically by Jules for task [14344935457335327621](https://jules.google.com/task/14344935457335327621) started by @Snider*