### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass in Nginx configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-03 - [CRITICAL] Fix hardcoded secret bypass in Nginx configuration
+**Vulnerability:** A hardcoded secret (`xrpc-9f8e7d6c5b4a`) was found in the Nginx configuration file `server-php/config/conf.d/wordpress.conf` which allowed bypass of the XML-RPC block (`/xmlrpc.php`). Anyone with the secret could access this endpoint.
+**Learning:** Hardcoding secrets directly in configuration files, especially ones committed to version control, is a critical security vulnerability as it easily exposes the secret to unauthorized personnel and attackers who gain read access to the code.
+**Prevention:** Never hardcode secrets in code or configuration files. If an endpoint must be blocked, use `deny all;` unconditionally, or implement proper authentication mechanisms configured via securely loaded environment variables or secret management systems.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🛡️ Sentinel found and fixed a critical security vulnerability:

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded secret (`xrpc-9f8e7d6c5b4a`) was found in the Nginx configuration file `server-php/config/conf.d/wordpress.conf` which allowed bypassing the XML-RPC block (`/xmlrpc.php`). Anyone with the secret could access this endpoint.
🎯 **Impact:** Exposing the secret bypass in version control allows unauthorized personnel or attackers to access the XML-RPC endpoint, potentially leading to brute-force or DDoS attacks on the WordPress instance.
🔧 **Fix:** Removed the hardcoded secret and conditionally blocked the XML-RPC endpoint using `deny all;` and disabled associated logs. Added a journal entry to `.jules/sentinel.md`.
✅ **Verification:** Verify the change by reading the `.conf` file or by running `nginx -t` with a wrapper configuration to ensure the syntax remains valid.

---
*PR created automatically by Jules for task [7844810785833469435](https://jules.google.com/task/7844810785833469435) started by @Snider*