### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret in Nginx configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-06-04 - [CRITICAL] Fix hardcoded secret in Nginx configuration
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in `/app/server-php/config/conf.d/wordpress.conf` to bypass the XML-RPC block (`/xmlrpc.php`). This could allow attackers to bypass access controls if the configuration file is leaked or the token is discovered.
+**Learning:** Hardcoding secrets directly in server configurations (like Nginx) poses a significant risk as these files are often tracked in version control and may be exposed. The `xmlrpc.php` endpoint in WordPress is a common vector for brute-force and DDoS attacks.
+**Prevention:** Remove hardcoded secrets from configuration files. If an endpoint is unnecessary, block it unconditionally. If authentication is required, use proper authentication mechanisms like environment variables injected at runtime, or basic auth, rather than static tokens checked in Nginx logic.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC completely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in `/app/server-php/config/conf.d/wordpress.conf` to bypass the XML-RPC block (`/xmlrpc.php`). This allowed a trivial bypass of access controls if the configuration file or the token was exposed.
🎯 Impact: Attackers could bypass the XML-RPC block and leverage the endpoint for brute-force attacks, DDoS amplification, or potentially other WordPress vulnerabilities.
🔧 Fix: Removed the custom `$arg_token` check and replaced it with a standard, unconditional `deny all;` directive for the `/xmlrpc.php` location. Added an entry to `.jules/sentinel.md` documenting this pattern and prevention.
✅ Verification: Ran `nginx -t` with a wrapper configuration to verify the syntax of `wordpress.conf` remains correct after the modification. Checked that the block now strictly contains `deny all;`, `access_log off;`, and `log_not_found off;`.

---
*PR created automatically by Jules for task [16363810001772889596](https://jules.google.com/task/16363810001772889596) started by @Snider*