### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass for XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Hardcoded Secret in Nginx Configuration Bypass]
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was used in `server-php/config/conf.d/wordpress.conf` to conditionally allow access to `/xmlrpc.php` via `$arg_token`.
+**Learning:** Hardcoding secrets directly in infrastructure configuration files (like Nginx) exposes them to anyone with repository access. Configuration files are typically not treated as secure secret storage mechanisms and are often stored in plain text.
+**Prevention:** Avoid hardcoding secrets in configuration files. If conditional access is required, implement robust authentication mechanisms at the application level or use secure secret management solutions that inject secrets at runtime without storing them in static configuration code. For XML-RPC, if it's not strictly necessary, it's safer to block it unconditionally.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token (`xrpc-9f8e7d6c5b4a`) was used in `server-php/config/conf.d/wordpress.conf` to conditionally allow access to `/xmlrpc.php` via `$arg_token`. Hardcoding secrets directly in infrastructure configuration files exposes them in version control.
🎯 Impact: Anyone with access to the repository or the configuration file could discover the token and bypass the intended XML-RPC restriction, potentially leading to brute-force attacks or DDoS amplification.
🔧 Fix: Removed the conditional logic and replaced it with an unconditional `deny all;` for the `/xmlrpc.php` location block.
✅ Verification: Ran `nginx -t` with an isolated wrapper script to confirm the syntax is correct.

---
*PR created automatically by Jules for task [1259946353828773790](https://jules.google.com/task/1259946353828773790) started by @Snider*