### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret for XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-06 - [Fix Hardcoded Secret in Nginx XML-RPC Bypass]
+**Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was used in `server-php/config/conf.d/wordpress.conf` to bypass the block on `/xmlrpc.php`.
+**Learning:** Hardcoding secrets directly in configuration files exposes the system to unauthorized access if the source code is compromised or if the configuration is inadvertently shared. The token acts as a static backdoor.
+**Prevention:** Never hardcode secrets in configuration files. If an endpoint needs to be blocked, block it unconditionally. If conditional access is required, implement dynamic authentication upstream or inject secrets securely via environment variables at runtime.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was used in `server-php/config/conf.d/wordpress.conf` to conditionally allow access to `/xmlrpc.php`, acting as a static backdoor if the configuration is exposed.
🎯 Impact: Unauthorized access via XML-RPC by anyone who obtains the configuration file, potentially leading to brute force attacks or further compromise.
🔧 Fix: Removed the conditional check based on the hardcoded token and replaced it with an unconditional `deny all;` for the `/xmlrpc.php` location.
✅ Verification: Tested configuration syntactically with `nginx -t` using a wrapper file. Confirmed `deny all;` is correctly applied. Added a learning log entry.

---
*PR created automatically by Jules for task [14664919858460756540](https://jules.google.com/task/14664919858460756540) started by @Snider*