### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix hardcoded XML-RPC backdoor in Nginx config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-07 - [CRITICAL] Fix Hardcoded Secret Bypass in XML-RPC configuration
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was left in the Nginx configuration `server-php/config/conf.d/wordpress.conf` which allowed bypassing the XML-RPC block (a common vector for brute force and amplification attacks).
+**Learning:** Development or debugging backdoors using `if ($arg_token = "...")` in Nginx configuration files expose the system to unauthorized access if committed to production.
+**Prevention:** Always unconditionally block access to sensitive files (like `xmlrpc.php`) with `deny all;` unless authenticated through proper, non-hardcoded mechanisms. Never commit secrets directly into source code or server configurations.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The Nginx configuration `server-php/config/conf.d/wordpress.conf` contained a hardcoded secret token (`xrpc-9f8e7d6c5b4a`) that bypassed the XML-RPC block (`location = /xmlrpc.php`). This creates a critical backdoor that can be used to execute brute-force attacks or amplification DDoS attacks against the WordPress application.
🎯 Impact: Unauthorized users with knowledge of the secret token could bypass the security block and exploit the XML-RPC endpoint.
🔧 Fix: Replaced the conditional bypass with an unconditional `deny all;` block for `/xmlrpc.php`, while also disabling logging to prevent access log spam.
✅ Verification: An Nginx syntax test using a temporary test configuration (`sudo nginx -t -c /tmp/test_nginx.conf`) confirmed the file's syntax remains valid after the modification. A new entry was added to the `.jules/sentinel.md` journal detailing the findings.

---
*PR created automatically by Jules for task [1740373456898496165](https://jules.google.com/task/1740373456898496165) started by @Snider*