### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-08 - [CRITICAL] Fixed Hardcoded Secret XML-RPC Bypass in Nginx
+**Vulnerability:** A hardcoded secret (`xrpc-9f8e7d6c5b4a`) was used in `server-php/config/conf.d/wordpress.conf` to allow access to the `/xmlrpc.php` endpoint via the query parameter `$arg_token`.
+**Learning:** Hardcoded secrets in Nginx configuration files provide a false sense of security and can easily be leaked through version control. Relying on query parameters for authorization is also insecure, as they can be logged by intermediary proxies or browser history.
+**Prevention:** Unconditionally block access to obsolete and frequently abused endpoints like `/xmlrpc.php` (`deny all;`). If access is truly required, use proper authentication mechanisms such as Basic Auth, IP allowlisting, or upstream authentication services, rather than hardcoded string matching.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration `server-php/config/conf.d/wordpress.conf`, which could be used as a query parameter (`token=xrpc-9f8e7d6c5b4a`) to bypass the XML-RPC block.
🎯 Impact: Hardcoded secrets in Nginx configuration files provide a false sense of security and can be easily leaked through version control. Relying on query parameters for authorization is also highly insecure, as they can be logged by intermediary proxies or browser history, potentially granting unauthorized access to the `/xmlrpc.php` endpoint.
🔧 Fix: Removed the `$arg_token` block entirely and replaced the location logic with an unconditional `deny all;` for `/xmlrpc.php`, also ensuring `access_log` and `log_not_found` are `off`. Added a Sentinel journal entry documenting the vulnerability, learning, and prevention.
✅ Verification: Ran `nginx -t` with a test configuration including the updated `wordpress.conf`, verifying that the syntax is correct.

---
*PR created automatically by Jules for task [1420042587411230029](https://jules.google.com/task/1420042587411230029) started by @Snider*