### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass for XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-06-09 - [CRITICAL] Hardcoded Authentication Bypass in Nginx Config
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` allowing a complete bypass of the `deny all` security control for XML-RPC (`/xmlrpc.php`). Attackers with knowledge of the configuration or through brute-forcing could use this token to access XML-RPC and launch pingback amplification attacks or brute-force user credentials.
+**Learning:** Hardcoding secrets directly into configuration files to provide temporary or conditional bypasses creates severe, persistent vulnerabilities that may easily leak through source control or server misconfigurations.
+**Prevention:** Never use hardcoded tokens for authorization or authentication in web server configurations. Rely on robust authentication mechanisms, proper API gateways, and block risky endpoints unconditionally if they are not required.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally to prevent abuse
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration, providing a complete bypass of the `deny all` security block for XML-RPC (`/xmlrpc.php`).
🎯 Impact: Attackers with knowledge of the configuration or through brute-forcing could use this token to access XML-RPC and launch pingback amplification attacks or brute-force user credentials.
🔧 Fix: Removed the hardcoded token and replaced it with an unconditional `deny all;` block for the `/xmlrpc.php` location. Also disabled access and not found logging for the blocked endpoint.
✅ Verification: Successfully verified Nginx configuration syntax using a test wrapper with `nginx -t`. No syntax errors were detected. Included a new journal entry to document the vulnerability and learning.

---
*PR created automatically by Jules for task [9036740341440347201](https://jules.google.com/task/9036740341440347201) started by @Snider*