### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret for XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-10 - [CRITICAL] Fix hardcoded secret for XML-RPC bypass
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) in `server-php/config/conf.d/wordpress.conf` was used to conditionally bypass the XML-RPC block (`/xmlrpc.php`), creating a backdoor that an attacker could easily discover and exploit.
+**Learning:** Hardcoded secrets in Nginx configuration files create permanent backdoors. Nginx's `$arg_token` mechanism is insecure when tied to static strings committed to source control.
+**Prevention:** Remove hardcoded conditional blocks for authentication. Block risky endpoints unconditionally (`deny all;`). If authentication is needed, use proper upstream authentication or environment variable substitution at runtime instead of hardcoding secrets in configuration files.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token (`xrpc-9f8e7d6c5b4a`) in `server-php/config/conf.d/wordpress.conf` was used to conditionally bypass the XML-RPC block (`/xmlrpc.php`), creating a backdoor that an attacker could easily discover and exploit.
🎯 Impact: Attackers who find the hardcoded secret (which is committed to source control) could bypass the intended restriction on `/xmlrpc.php` to perform brute force attacks, pingback exploits, and more.
🔧 Fix: Removed the conditional block and unconditionally blocked access to `/xmlrpc.php` with `deny all;`. Also added a Sentinel journal entry documenting the vulnerability, learning, and prevention strategy.
✅ Verification: Tested the updated `wordpress.conf` syntax using `sudo nginx -t` (after copying necessary files to `/tmp`). The syntax check passed cleanly.

---
*PR created automatically by Jules for task [11968117205726393440](https://jules.google.com/task/11968117205726393440) started by @Snider*