### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded token for XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-17 - [Fix hardcoded token for XML-RPC bypass]
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was used in `server-php/config/conf.d/wordpress.conf` to conditionally allow access to `/xmlrpc.php`, a known high-risk WordPress endpoint.
+**Learning:** Hardcoded secrets in Nginx configuration files create an easily exploitable bypass since the configuration is deployed as static text. If an attacker discovers the secret (e.g., through a misconfiguration, commit history, or repository access), they can bypass the intended security restrictions.
+**Prevention:** Remove conditional access based on hardcoded secrets in Nginx configurations. Deny access to sensitive or deprecated endpoints unconditionally. If an endpoint must be accessible, use a robust, standard authentication mechanism (e.g., HTTP Basic Auth, OAuth, or IP whitelisting) managed outside the raw configuration file.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration `server-php/config/conf.d/wordpress.conf` to conditionally bypass the block on `/xmlrpc.php`. Nginx configuration files are inherently static, meaning any hardcoded secret is easily discoverable through commit history, misconfigurations, or internal repository access, creating a persistent backdoor.
🎯 **Impact**: An attacker who discovers this hardcoded token could append `?token=xrpc-9f8e7d6c5b4a` to bypass the intended block on the highly vulnerable WordPress XML-RPC endpoint. This endpoint is frequently targeted for brute-force attacks and DDoS reflection.
🔧 **Fix**: Removed the conditional token checking logic and replaced it with an unconditional `deny all;` for the `/xmlrpc.php` location, enforcing the block permanently. Also documented this anti-pattern in the Sentinel journal.
✅ **Verification**: The Nginx syntax was checked and verified using `nginx -t` with a temporary wrapper configuration.

_Fix performed by Sentinel 🛡️_

---
*PR created automatically by Jules for task [6918569513697356567](https://jules.google.com/task/6918569513697356567) started by @Snider*