### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret in XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-27 - [CRITICAL] Fix hardcoded secret in XML-RPC bypass
+**Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` to conditionally allow access to the `/xmlrpc.php` endpoint. This could allow attackers who discover the token to exploit WordPress XML-RPC vulnerabilities (e.g., brute-force attacks, pingback attacks).
+**Learning:** Hardcoded secrets in Nginx configuration files provide a false sense of security and are easily discovered if the repository is accessible. Security should not rely on obscurity.
+**Prevention:** Unconditionally block sensitive endpoints like `/xmlrpc.php` in Nginx configuration using `deny all`. If access is required, use robust authentication mechanisms instead of hardcoded tokens in the configuration file.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC entirely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` to conditionally allow access to the `/xmlrpc.php` endpoint. 
🎯 **Impact:** This could allow attackers who discover the token to exploit WordPress XML-RPC vulnerabilities (e.g., brute-force attacks, pingback attacks). Security should not rely on obscurity.
🔧 **Fix:** Modified the Nginx configuration to unconditionally block the `/xmlrpc.php` endpoint using `deny all;`. Disabled logging for this endpoint. Added an entry to `.jules/sentinel.md` to document the learning.
✅ **Verification:** Verified Nginx syntax using `nginx -t` with a mocked setup. Docker build functionality was tested. Code review has approved the change.

---
*PR created automatically by Jules for task [14199412349338180272](https://jules.google.com/task/14199412349338180272) started by @Snider*