### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC bypass token in Nginx configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-15 - Remove Hardcoded XML-RPC Token
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` allowing unauthorized access to the `/xmlrpc.php` endpoint.
+**Learning:** Hardcoding secrets or bypass tokens in Nginx configuration files creates a critical security vulnerability that can be exploited by anyone who discovers the token, especially since it is checked unconditionally.
+**Prevention:** Remove hardcoded tokens from configuration files. Access to sensitive endpoints should be controlled via secure, properly authenticated mechanisms, or blocked entirely by returning 403 or 444 if the endpoint is not needed.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC entirely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration file (`server-php/config/conf.d/wordpress.conf`), which allowed unauthorized users to access the `/xmlrpc.php` endpoint.
🎯 **Impact:** An attacker who discovers the token could completely bypass the Nginx block and execute potentially harmful XML-RPC requests against the WordPress installation, such as brute force attacks or DDoS reflection.
🔧 **Fix:** Removed the hardcoded token check. Replaced the logic with a simple `deny all;` directive inside the `/xmlrpc.php` location block, making the block unconditional. Also disabled access and error logging for these denied requests to prevent log spamming.
✅ **Verification:** Verified by creating a temporary Nginx wrapper and running `sudo nginx -t -c test_nginx.conf` which succeeded. The configuration no longer contains the `$arg_token` check.

A new entry was also added to the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [10793937812065635350](https://jules.google.com/task/10793937812065635350) started by @Snider*