### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret in Nginx XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-06-16 - [Hardcoded Authentication Secret in Nginx Config]
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was found in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`) to bypass the block on `/xmlrpc.php` via `$arg_token`.
+**Learning:** Checking query parameters like `$arg_token` for hardcoded static secrets directly in Nginx configuration files exposes sensitive access mechanisms, as configuration files are often tracked in version control.
+**Prevention:** Avoid embedding hardcoded secrets directly into Nginx configurations. If an endpoint like XML-RPC must be blocked, do it unconditionally (`deny all;`). For authenticated bypasses, rely on proper upstream authentication mechanisms instead of Nginx variable checks.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded static token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration `server-php/config/conf.d/wordpress.conf`. It was checked via the `$arg_token` query parameter to allow bypassing the block on the `/xmlrpc.php` endpoint. Because this configuration file is tracked in version control, this secret token is exposed to anyone with access to the repository, entirely defeating its purpose and leaving the XML-RPC endpoint open to exploitation.
🎯 **Impact:** An attacker who discovers the token could completely bypass the XML-RPC protection. WordPress XML-RPC endpoints are notorious for being used in brute-force password attacks and DDoS amplification attacks. Exposing it means the site is vulnerable to these attacks.
🔧 **Fix:** Replaced the insecure token check with an unconditional `deny all;` block on `/xmlrpc.php`, following standard WordPress security best practices to disable it entirely when not strictly necessary. Also ensured `access_log` and `log_not_found` are `off` to prevent log bloat.
✅ **Verification:** A temporary Nginx config file was used along with `sudo nginx -t` to confirm that the Nginx configuration syntax remains correct.
📖 **Journal:** Updated `.jules/sentinel.md` with a critical learning regarding the danger of using `$arg_token` or similar variables with static secrets in Nginx config files.

---
*PR created automatically by Jules for task [10927790111798613905](https://jules.google.com/task/10927790111798613905) started by @Snider*