### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret bypass vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-27 - [CRITICAL] Fixed Hardcoded XML-RPC Secret Bypass
+**Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in `server-php/config/conf.d/wordpress.conf` which allowed bypassing the default block on `/xmlrpc.php` endpoints. Attackers could find this in the repository and easily abuse it to perform brute-force attacks or exploit other vulnerabilities.
+**Learning:** Hardcoded tokens or backdoors left in configuration files bypass core security measures, nullifying the value of those measures. Security bypasses must never rely on static values stored in version control.
+**Prevention:** Remove all hardcoded secret checks for endpoints that should be restricted. For restricted features like XML-RPC that are largely obsolete, they should be unconditionally blocked in the configuration file using `deny all;` and the logs should be disabled to prevent log spamming or DoS attempts.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC entirely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in the Nginx configuration which allowed bypassing the default block on `/xmlrpc.php` endpoints. Attackers could discover this in version control and easily abuse it.
🎯 Impact: Attackers could leverage the allowed XML-RPC endpoint to perform brute-force attacks, pingback DDoS attacks, or exploit other vulnerabilities, circumventing the intended security measures.
🔧 Fix: Removed the hardcoded secret check and unconditionally blocked the `/xmlrpc.php` endpoint using `deny all;`. Additionally disabled `access_log` and `log_not_found` to prevent log spamming or disk exhaustion attempts. Added a critical learning entry to `.jules/sentinel.md`.
✅ Verification: Verified the `wordpress.conf` configuration syntax changes using a local wrapper and `nginx -t`. Tested locally that `docker build` fails expectedly due to sandbox constraint but logic holds true.

---
*PR created automatically by Jules for task [9467353835172644952](https://jules.google.com/task/9467353835172644952) started by @Snider*