### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass for XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-18 - [Fix Hardcoded XML-RPC Secret Bypass]
+**Vulnerability:** A hardcoded Nginx environment secret (`$arg_token = "xrpc-9f8e7d6c5b4a"`) was implemented to bypass the security block on `/xmlrpc.php`, a notoriously vulnerable and heavily attacked endpoint in WordPress. This could be trivially exploited via a simple parameter (`/xmlrpc.php?token=xrpc-9f8e7d6c5b4a`), compromising the defense.
+**Learning:** Adding hardcoded secret checks to Nginx locations for critical functions creates severe vulnerabilities and bypasses intended security controls. Such bypasses are likely to be found or leaked.
+**Prevention:** Unconditionally deny access to known dangerous endpoints in Nginx configuration using `deny all;` and disable logging for them using `access_log off;` and `log_not_found off;`. Avoid entirely hardcoding any environment or access secrets within static configuration files.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC completely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded Nginx environment secret (`$arg_token = "xrpc-9f8e7d6c5b4a"`) was implemented to bypass the security block on `/xmlrpc.php`, a historically vulnerable endpoint in WordPress.
🎯 **Impact:** An attacker could trivially bypass intended security controls and access the `/xmlrpc.php` endpoint simply by appending `?token=xrpc-9f8e7d6c5b4a` to their request, exposing the application to brute-force and DDoS attacks commonly associated with XML-RPC.
🔧 **Fix:** Removed the insecure hardcoded secret check and `fastcgi` pass-throughs from the `/xmlrpc.php` location block in `server-php/config/conf.d/wordpress.conf`. Replaced it with a standard, unconditional `deny all;` directive along with `access_log off;` and `log_not_found off;` to prevent log pollution from automated scanners. Also logged the vulnerability in the Sentinel journal.
✅ **Verification:** Verified that the Nginx configuration syntax remains correct using `nginx -t` within a temporary wrapper configuration.

*Note: Docker image build verification failed due to expected environment limitations (overlay fs), but the configuration syntax passed.*

---
*PR created automatically by Jules for task [13023256614173473848](https://jules.google.com/task/13023256614173473848) started by @Snider*