### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret in Nginx configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-19 - Hardcoded Secret in Nginx Config
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was used in `server-php/config/conf.d/wordpress.conf` to bypass the block on `/xmlrpc.php`.
+**Learning:** Hardcoded secrets in infrastructure configuration files create significant security vulnerabilities. If this configuration is leaked or checked into version control, attackers can bypass security controls. Authentication logic should not rely on static tokens embedded in proxy configurations.
+**Prevention:** Never use hardcoded tokens for access control in Nginx configurations. Endpoints like `xmlrpc.php` should be unconditionally blocked (`deny all;`) if they are not needed.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was embedded in `server-php/config/conf.d/wordpress.conf` to selectively allow access to `/xmlrpc.php`.
🎯 Impact: If this configuration is leaked or checked into version control, attackers can easily bypass security controls and exploit XML-RPC for brute-force attacks or DDoS amplification.
🔧 Fix: Removed the token-based bypass logic and unconditionally blocked `/xmlrpc.php` using `deny all;`, `access_log off;`, and `log_not_found off;`. Also journaled the finding in `.jules/sentinel.md`.
✅ Verification: Ran `nginx -t` with the isolated configuration snippet to ensure syntax correctness.

---
*PR created automatically by Jules for task [6483469792472076655](https://jules.google.com/task/6483469792472076655) started by @Snider*