### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass in XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - [CRITICAL] Fix hardcoded secret bypass in XML-RPC
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration for WordPress (`wordpress.conf`), allowing a bypass to access the `/xmlrpc.php` endpoint which is otherwise blocked.
+**Learning:** Hardcoding secrets directly into configuration files or application logic is a critical security risk. It bypasses proper authentication mechanisms and provides a backdoor that is trivial to exploit if the configuration is exposed.
+**Prevention:** Unconditionally block sensitive or deprecated endpoints like `/xmlrpc.php` in Nginx. If access is genuinely required, use robust upstream authentication mechanisms rather than simple query parameter tokens.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration for WordPress (`wordpress.conf`), allowing a bypass to access the `/xmlrpc.php` endpoint which is otherwise blocked. Hardcoding secrets directly into configuration files is a critical security risk as it bypasses proper authentication mechanisms and provides a backdoor.
🎯 Impact: An attacker who discovers the configuration file or the token could bypass the block and access the `xmlrpc.php` endpoint, which is notorious for brute-force and DDoS attacks in WordPress.
🔧 Fix: Removed the hardcoded `$arg_token` check and updated the `location = /xmlrpc.php` block to unconditionally block traffic with `deny all;`, `access_log off;`, and `log_not_found off;`. Added a critical learning entry to `.jules/sentinel.md`.
✅ Verification: Tested Nginx configuration syntax with `nginx -t` using a wrapper configuration file to confirm syntax is ok.

---
*PR created automatically by Jules for task [10782099213014523921](https://jules.google.com/task/10782099213014523921) started by @Snider*