### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC bypass secret

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-23 - [CRITICAL] Hardcoded XML-RPC bypass secret
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was discovered in `server-php/config/conf.d/wordpress.conf` which allowed a direct bypass of the XML-RPC block (via `/xmlrpc.php?token=...`).
+**Learning:** Hardcoded bypass tokens in load balancer or reverse proxy configurations often go unnoticed because they are designed to "facilitate" internal tasks, bypassing normal authentication flows, presenting a critical security risk if the token leaks or is discovered via configuration inspection.
+**Prevention:** Do not leave hardcoded secret tokens in infrastructure configurations. Rely on proper upstream authentication or strictly allow-list connections only from known, authenticated internal IPs if such a backdoor is deemed absolutely necessary.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was discovered in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`) that allowed any user with the token to completely bypass the XML-RPC block (via `/xmlrpc.php?token=xrpc-9f8e7d6c5b4a`).
🎯 **Impact:** If this token leaked or was guessed, attackers could bypass security controls to brute-force credentials, perform XML-RPC pingback amplification attacks (DDoS), or exploit vulnerabilities in the WordPress XML-RPC implementation.
🔧 **Fix:** Replaced the conditional bypass block with a secure, unconditional block (`deny all;`) for `/xmlrpc.php`, ensuring no backdoor access exists.
✅ **Verification:** Manually verified the updated configuration syntax with `nginx -t` using a temporary test harness. Checked that the configuration strictly enforces `deny all;` for the endpoint. Added a critical learning entry to the Sentinel journal.

---
*PR created automatically by Jules for task [16791252066609265649](https://jules.google.com/task/16791252066609265649) started by @Snider*