### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret in Nginx configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-06-23 - [Fix hardcoded secret in Nginx configuration]
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was found in the `wordpress.conf` Nginx configuration file, allowing bypass of the XML-RPC block (`/xmlrpc.php?token=xrpc-9f8e7d6c5b4a`).
+**Learning:** Hardcoded secrets in Nginx configuration files present a critical security vulnerability as they allow unauthorized access or bypasses and are difficult to rotate. In this case, it permitted access to XML-RPC, a feature often targeted by attackers for amplification and brute-force attacks.
+**Prevention:** Unconditionally block sensitive endpoints if they are not needed, or use proper upstream authentication mechanisms instead of hardcoded secrets in configuration files.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret in Nginx configuration

🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token (`xrpc-9f8e7d6c5b4a`) was found in the `server-php/config/conf.d/wordpress.conf` Nginx configuration file, allowing bypass of the XML-RPC block (`/xmlrpc.php?token=xrpc-9f8e7d6c5b4a`).
🎯 Impact: An attacker who discovers the hardcoded secret in the codebase could bypass the security block and access the `/xmlrpc.php` endpoint. XML-RPC is a legacy WordPress endpoint often targeted for brute-force attacks and DDoS amplification.
🔧 Fix: Removed the secret-based bypass logic and replaced it with an unconditional `deny all;` for the `/xmlrpc.php` location block.
✅ Verification: The Nginx configuration was validated for syntax correctness using `nginx -t`, and the vulnerable code block was successfully replaced.

---
*PR created automatically by Jules for task [9347203238059524539](https://jules.google.com/task/9347203238059524539) started by @Snider*