### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC bypass token

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-24 - [CRITICAL] Fix hardcoded XML-RPC bypass token
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was discovered in `server-php/config/conf.d/wordpress.conf` allowing a bypass for the XML-RPC endpoint block using `$arg_token`.
+**Learning:** Hardcoded secrets in Nginx configuration files expose the system to unauthorized access since configuration files are often committed to version control and are accessible to anyone with codebase access. In this case, an attacker could potentially abuse WordPress XML-RPC functionalities.
+**Prevention:** Unconditionally deny access to endpoints that shouldn't be publicly available, or implement a proper authentication mechanism via a backend service or secure proxy configuration rather than relying on secret strings within Nginx conditionals.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was discovered in `server-php/config/conf.d/wordpress.conf` allowing a bypass for the XML-RPC endpoint block using the `$arg_token` query parameter.
🎯 **Impact:** An attacker discovering this token could abuse WordPress XML-RPC functionalities, potentially leading to brute-force attacks, DDoS amplification, or unauthorized content modification.
🔧 **Fix:** Replaced the conditional `$arg_token` check with an unconditional `deny all;` for the `/xmlrpc.php` location block, along with disabling access and not-found logging. Created a `.jules/sentinel.md` journal entry.
✅ **Verification:** Syntactically verified the Nginx configuration using `nginx -t` with a minimal wrapper and verified the file contents directly.

---
*PR created automatically by Jules for task [12395925114808874957](https://jules.google.com/task/12395925114808874957) started by @Snider*