### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass for XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-06-25 - [Fix Critical] Remove Hardcoded Secret Bypass in XML-RPC
+**Vulnerability:** A hardcoded authentication bypass was found in the Nginx configuration `server-php/config/conf.d/wordpress.conf` for the `/xmlrpc.php` endpoint. The configuration allowed access if the `$arg_token` matched a specific string (`xrpc-9f8e7d6c5b4a`).
+**Learning:** Hardcoded secrets in configuration files are a critical risk because they provide an undocumented and easily discoverable mechanism to bypass security controls, especially when the codebase is accessible or inadvertently leaked.
+**Prevention:** Unconditionally block access to sensitive endpoints like `/xmlrpc.php` using `deny all;` in Nginx configurations. If access is genuinely required, use proper external authentication mechanisms (like mutual TLS or dedicated auth upstream servers) instead of embedding secrets in static configuration logic.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Unconditionally block XML-RPC to prevent brute-force attacks
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded secret (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration, providing a bypass mechanism for the `/xmlrpc.php` endpoint block.
🎯 Impact: An attacker who discovers this token or accesses the source code can exploit the XML-RPC endpoint, potentially leading to brute-force attacks against user credentials, denial-of-service, or other XML-RPC related vulnerabilities.
🔧 Fix: Replaced the conditional `$arg_token` logic with an unconditional `deny all;` for the `/xmlrpc.php` location block in `server-php/config/conf.d/wordpress.conf`. Access and not_found logging for this endpoint were also disabled.
✅ Verification: Ensure the updated Nginx configuration syntax is valid by running `nginx -t`. Verify that requests to `/xmlrpc.php`, even with the previous token, return a 403 Forbidden.

---
*PR created automatically by Jules for task [8240612444678263364](https://jules.google.com/task/8240612444678263364) started by @Snider*