### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret for XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-26 - [CRITICAL] Fix hardcoded secret for XML-RPC bypass
+**Vulnerability:** Found a hardcoded authentication bypass token (`xrpc-9f8e7d6c5b4a`) in `server-php/config/conf.d/wordpress.conf` that allows access to `/xmlrpc.php`, overriding the default block.
+**Learning:** Hardcoding secrets directly in configuration files exposes the application to unauthorized access, especially when configuration files are version controlled or built directly into images. Nginx configuration should not be used as an authentication mechanism with hardcoded secrets.
+**Prevention:** Unconditionally block sensitive endpoints like `/xmlrpc.php` in Nginx. If access is required, use proper authentication mechanisms or IP allowlisting instead of query parameter secrets.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: A hardcoded authentication bypass token (`xrpc-9f8e7d6c5b4a`) was discovered in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`). This allowed an attacker to bypass the default `/xmlrpc.php` access block simply by appending `?token=xrpc-9f8e7d6c5b4a` to the query string.
🎯 **Impact**: Anyone with knowledge of this hardcoded secret could access the `xmlrpc.php` endpoint, which is commonly targeted for brute-force login attempts, DDoS amplification attacks, and other WordPress exploits. Since the configuration is version-controlled, this secret is highly vulnerable to leakage.
🔧 **Fix**: Removed the conditional logic checking for the `$arg_token` and replaced it with a strict, unconditional `deny all;` for the `/xmlrpc.php` endpoint. Access logging for this endpoint is also disabled to prevent log pollution from automated scanners. Added learning to Sentinel Journal.
✅ **Verification**: The Nginx configuration was validated using `nginx -t` with a synthetic wrapper, passing successfully. Attempting to build the image was also confirmed to not introduce any new blockers to the source configuration.

---
*PR created automatically by Jules for task [5936261234073497465](https://jules.google.com/task/5936261234073497465) started by @Snider*