### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass in XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [CRITICAL] Fix hardcoded secret bypass in XML-RPC
+**Vulnerability:** Found a hardcoded token check (`if ($arg_token = "xrpc-9f8e7d6c5b4a")`) in the Nginx configuration for `/xmlrpc.php`, which allowed attackers to bypass security restrictions and access the endpoint unconditionally if they provided this token.
+**Learning:** Hardcoded secrets in Nginx configuration files, such as `$arg_token` checks to bypass an intended restriction, act as backdoors and are a critical vulnerability.
+**Prevention:** Always unconditionally block sensitive endpoints like `/xmlrpc.php` if not in use, or use a proper upstream authentication mechanism rather than embedding secrets in the configuration files directly.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The Nginx configuration for WordPress (`wordpress.conf`) contained a hardcoded secret token (`xrpc-9f8e7d6c5b4a`) that allowed users to bypass the block on the `/xmlrpc.php` endpoint.
🎯 Impact: Attackers who discovered this hardcoded token could bypass intended security restrictions, allowing them to access the `/xmlrpc.php` endpoint which is often targeted for brute-force attacks, DDoS attacks, and unauthorized interactions.
🔧 Fix: Removed the backdoor logic and unconditionally blocked access to `/xmlrpc.php` using `deny all;` while turning off access and not_found logs. Also added an entry to `.jules/sentinel.md` recording this vulnerability.
✅ Verification: Ensure Nginx syntax is correct using `nginx -t`. Verify the `/xmlrpc.php` endpoint returns a 403 Forbidden for all requests, regardless of parameters.

---
*PR created automatically by Jules for task [17739458492938170239](https://jules.google.com/task/17739458492938170239) started by @Snider*