### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass for XML-RPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-06-28 - [CRITICAL] Fix hardcoded secret bypass for XML-RPC
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was present in the Nginx reverse proxy configuration (`wordpress.conf`) to conditionally bypass a block on `/xmlrpc.php`. This violates the security rule against hardcoded secrets and provides a backdoor.
+**Learning:** Checking query parameters like `$arg_token` for hardcoded secrets in Nginx configuration files is a security anti-pattern and can be exploited.
+**Prevention:** Remove unconditional secret checks in proxy blocks and instead use robust authentication methods or unconditionally deny access to sensitive endpoints.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token `xrpc-9f8e7d6c5b4a` was present in the Nginx reverse proxy configuration (`wordpress.conf`) to conditionally bypass a block on `/xmlrpc.php`. This violates the security rule against hardcoded secrets and provides a backdoor.
🎯 Impact: Anyone with knowledge of this token could bypass the intended block on XML-RPC and potentially exploit it (e.g., for brute-force attacks or DDoS amplification against the WordPress installation).
🔧 Fix: Removed the conditional `$arg_token` check and replaced it with an unconditional `deny all;` while turning off access and not_found logs.
✅ Verification: Use `nginx -t` with a test configuration wrapping `wordpress.conf` to ensure syntax is valid and no regressions are introduced. Check the `/xmlrpc.php` location block in `server-php/config/conf.d/wordpress.conf` to confirm the unconditional block.

---
*PR created automatically by Jules for task [12681493953499704016](https://jules.google.com/task/12681493953499704016) started by @Snider*