### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret bypass in Nginx configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [CRITICAL] Fix hardcoded secret bypass in Nginx configuration
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was left in the Nginx configuration for `server-php/config/conf.d/wordpress.conf` to allow bypass of the default `xmlrpc.php` restriction. Anyone with this token could bypass the block and access the XML-RPC endpoint, potentially leading to brute force or other attacks if the token leaked or was guessed.
+**Learning:** Hardcoded secrets in infrastructure configurations (like Nginx `$arg_token` checks) are a significant security risk, especially in public or widely distributed images. The configuration should not bake in secrets.
+**Prevention:** Remove all hardcoded secret checks. Security boundaries (like blocking an endpoint) should be absolute (`deny all;`) or rely on dynamic authentication mechanisms outside of static configuration files.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC access completely
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` to bypass the XML-RPC block.
🎯 **Impact:** If this static token was leaked or guessed, an attacker could bypass the intended restriction and access the `xmlrpc.php` endpoint, opening up vectors for brute-force attacks and DDoS.
🔧 **Fix:** Removed the hardcoded token check and replaced it with an absolute `deny all;` directive, effectively disabling XML-RPC completely.
✅ **Verification:** Nginx syntax verified successfully using `nginx -t` with a synthesized wrapper configuration.

---
*PR created automatically by Jules for task [14524248427008651975](https://jules.google.com/task/14524248427008651975) started by @Snider*