### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded secret and XML-RPC auth bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2025-02-14 - [CRITICAL] Hardcoded Secret and Authorization Bypass via Nginx XML-RPC
+
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf`. It bypassed the XML-RPC block (which was intended to deny access) if the `token` URL query parameter matched the secret.
+
+**Learning:** Hardcoding secrets directly in server configurations (like Nginx) bypasses proper authentication mechanisms and secrets management. It can easily lead to authorization bypass because the configuration files are typically checked into source control and visible to all developers, creating a direct attack vector against specific endpoints (e.g., XML-RPC in WordPress, which is often targeted for brute force and amplification attacks).
+
+**Prevention:** Never hardcode secrets in infrastructure or application configurations. Ensure that external endpoints like XML-RPC are either fully disabled or secured using robust, centralized authentication mechanisms (e.g., proper upstream authorization endpoints, WAF rules, or identity providers).

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:** A hardcoded authentication token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf`. It functioned as a backdoor to bypass the XML-RPC block if the `token` URL query parameter matched the secret.

🎯 **Impact:** This vulnerability could easily lead to an authorization bypass. Nginx configurations are typically checked into source control and visible to all developers, creating a direct attack vector against XML-RPC in WordPress, which is often targeted for brute force and DDoS amplification attacks.

🔧 **Fix:** The hardcoded token block was completely removed, and access to `/xmlrpc.php` was unconditionally blocked using `deny all;`, with logging disabled to avoid filling up logs during potential attacks. A journal entry was also added to `.jules/sentinel.md` documenting this security pattern.

✅ **Verification:** Verified that `nginx -t` reports a syntactically correct configuration and that the location block now correctly implements `deny all;` without any conditional checks.

---
*PR created automatically by Jules for task [15690478874684010062](https://jules.google.com/task/15690478874684010062) started by @Snider*