### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded token XML-RPC bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-01 - [CRITICAL] Fix hardcoded token XML-RPC bypass
+**Vulnerability:** Hardcoded token backdoor for XML-RPC (`$arg_token = "xrpc-9f8e7d6c5b4a"`).
+**Learning:** Hardcoded strings in nginx configs for bypasses circumvent standard application authentication and are trivial to abuse.
+**Prevention:** Unconditionally block sensitive endpoints at the webserver level or rely on robust authentication mechanisms, avoiding explicit hardcoded strings.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # XML-RPC unconditionally blocked
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
Replaced the hardcoded secret token (`xrpc-9f8e7d6c5b4a`) that acted as a backdoor to access `xmlrpc.php` in Nginx configuration. Updated the location block to unconditionally block XML-RPC.
Also logged this critical vulnerability in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [12946249166396063131](https://jules.google.com/task/12946249166396063131) started by @Snider*