### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded Nginx secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-04 - [Hardcoded Nginx Secret Bypass]
+**Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in Nginx configuration `server-php/config/conf.d/wordpress.conf` to bypass the block on `/xmlrpc.php`.
+**Learning:** Hardcoded secrets in Nginx configurations can be exposed and compromised. Upstream authentication mechanisms should be used instead.
+**Prevention:** Never use `$arg_` checks with hardcoded strings for access control. Always block sensitive endpoints unconditionally or rely on robust authentication systems.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was present in the Nginx configuration (`server-php/config/conf.d/wordpress.conf`) allowing a bypass to the block on `/xmlrpc.php`.
🎯 **Impact:** If an attacker discovered or guessed this secret token, they could access the `/xmlrpc.php` endpoint, which is a common vector for brute-force attacks and DDoS amplification against WordPress sites. Furthermore, exposing hardcoded secrets in source code is fundamentally insecure.
🔧 **Fix:** Completely removed the conditional `$arg_token` check and replaced it with a strict, unconditional `deny all;` for the `/xmlrpc.php` location block. Additionally, updated the `.jules/sentinel.md` journal with this critical learning.
✅ **Verification:** A syntax check using `nginx -t` was performed against the modified configuration file to ensure no syntax regressions were introduced. The `.jules/sentinel.md` file was successfully created/updated.

---
*PR created automatically by Jules for task [12274194874180127691](https://jules.google.com/task/12274194874180127691) started by @Snider*