### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded token bypass for xmlrpc.php

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-05 - [Hardcoded xmlrpc.php token in Nginx config]
+**Vulnerability:** A hardcoded token `xrpc-9f8e7d6c5b4a` was used in `server-php/config/conf.d/wordpress.conf` to bypass the block on `/xmlrpc.php`.
+**Learning:** Hardcoded secrets in infrastructure configuration provide a false sense of security and can easily leak via source control, granting permanent unauthorized access.
+**Prevention:** Instead of using hardcoded secrets in Nginx for application functionality, use robust upstream authentication, or simply block high-risk obsolete endpoints like `/xmlrpc.php` completely.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally to prevent abuse
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` allowing a bypass to the default block on the `/xmlrpc.php` endpoint.
🎯 **Impact:** Hardcoded secrets in infrastructure configuration provide a false sense of security and can easily leak via source control, granting attackers permanent unauthorized access to a highly-abused, legacy WordPress endpoint often used for brute force and DDoS amplification attacks.
🔧 **Fix:** Replaced the conditional block with an unconditional `deny all;` for the `/xmlrpc.php` location. Also added `access_log off;` and `log_not_found off;` to prevent log spamming from automated probing. Logged the finding in `.jules/sentinel.md`.
✅ **Verification:** Verified syntax correctness by running `nginx -t` with a test wrapper against the modified snippet and against the main configuration file.

---
*PR created automatically by Jules for task [2590706873642635295](https://jules.google.com/task/2590706873642635295) started by @Snider*