### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [CRITICAL] Fix hardcoded XML-RPC secret bypass in Nginx config
+**Vulnerability:** A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` to conditionally allow access to `/xmlrpc.php` which was otherwise blocked.
+**Learning:** Hardcoded secrets in infrastructure configuration files (like Nginx) create severe security vulnerabilities. Attackers gaining access to the config can easily bypass restrictions.
+**Prevention:** Never use hardcoded secrets in Nginx configuration files. For endpoint blocking, use unconditional `deny all;`. If authentication is genuinely required, utilize proper upstream authentication mechanisms or environment variables injected securely at runtime, though in this case blocking XML-RPC outright is standard security practice for modern WordPress deployments.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC by default (removed hardcoded secret token bypass)
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A hardcoded token (`xrpc-9f8e7d6c5b4a`) was present in `server-php/config/conf.d/wordpress.conf` to conditionally allow access to `/xmlrpc.php` which was otherwise blocked.
🎯 Impact: Attackers who discover the hardcoded token can bypass the intended restrictions and access the WordPress XML-RPC endpoint, potentially launching DDoS or brute-force attacks.
🔧 Fix: Removed the hardcoded secret token bypass and replaced it with an unconditional `deny all;` block for `/xmlrpc.php`.
✅ Verification: Tested the Nginx configuration using `nginx -t` with a wrapper configuration and verified syntax is OK. Checked that the hardcoded token is no longer present in the configuration files using `grep`.

---
*PR created automatically by Jules for task [1228267805294688625](https://jules.google.com/task/1228267805294688625) started by @Snider*