### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded XML-RPC secret bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-08 - [Hardcoded Secret Bypass in Nginx]
+**Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in the Nginx configuration (`wordpress.conf`) to bypass the XML-RPC block via `$arg_token`.
+**Learning:** Nginx configurations in this codebase sometimes implement custom authentication/bypass logic using hardcoded tokens in `$arg_token` variables, which exposes secrets in plaintext and bypasses proper upstream authentication.
+**Prevention:** Strictly prohibit hardcoded secrets in configuration files. Replace token checks with unconditional blocks (`deny all;`) or proper authentication mechanisms at the application level. Disable logging (`access_log off; log_not_found off;`) for unconditionally blocked endpoints to prevent log flooding.

--- a/server-php/config/conf.d/wordpress.conf
+++ b/server-php/config/conf.d/wordpress.conf
@@ -105,28 +105,11 @@ server {
         access_log off;
     }
 
-    # Block XML-RPC by default, allow with secret token
-    # Usage: /xmlrpc.php?token=YOUR_XMLRPC_TOKEN
+    # Block XML-RPC unconditionally
     location = /xmlrpc.php {
-        set $xmlrpc_allowed 0;
-
-        # Allow if valid token provided (set in environment or change here)
-        if ($arg_token = "xrpc-9f8e7d6c5b4a") {
-            set $xmlrpc_allowed 1;
-        }
-
-        # Block if no valid token
-        if ($xmlrpc_allowed = 0) {
-            return 403;
-        }
-
-        # Pass to PHP if allowed
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_index index.php;
-        include fastcgi_params;
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 
     # Deny access to hidden files


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A hardcoded secret token (`xrpc-9f8e7d6c5b4a`) was found in the Nginx configuration (`wordpress.conf`) to bypass the XML-RPC block via the `$arg_token` query parameter. This insecure logic exposes the secret in plaintext in the codebase and circumvents proper authentication mechanisms.
🎯 **Impact:** An attacker who discovers the token could completely bypass the XML-RPC restrictions, enabling large-scale brute force attacks, credential stuffing, and DDoS attacks against the WordPress instance, which the block was explicitly intended to prevent.
🔧 **Fix:** Replaced the conditional `$arg_token` bypass logic with a strict, unconditional `deny all;` directive for the `/xmlrpc.php` endpoint. Access and error logs are disabled for this endpoint to prevent log flooding during scanning attacks.
✅ **Verification:** Verified that the Nginx configuration syntax remains valid after the changes using `nginx -t` with a test configuration wrapper.

---
*PR created automatically by Jules for task [1330159667564915879](https://jules.google.com/task/1330159667564915879) started by @Snider*